### PR TITLE
components: fix Class.propTypes instead of Class.Proptypes

### DIFF
--- a/src/components/billing/Billing.tsx
+++ b/src/components/billing/Billing.tsx
@@ -483,7 +483,7 @@ class Billing extends React.Component {
   }
 }
 
-Billing.PropTypes = {
+Billing.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/calendar/Calendario.tsx
+++ b/src/components/calendar/Calendario.tsx
@@ -329,7 +329,7 @@ class Calendario extends React.Component<Props, State> {
   }
 }
 
-Calendar.PropTypes = {
+Calendar.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/login/login.tsx
+++ b/src/components/login/login.tsx
@@ -328,7 +328,7 @@ class Login extends React.Component {
   }
 }
 
-Login.PropTypes = {
+Login.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/news/News.tsx
+++ b/src/components/news/News.tsx
@@ -306,7 +306,7 @@ class News extends React.Component {
   }
 }
 
-News.PropTypes = {
+News.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/news/newsDetails/NewsDetails.tsx
+++ b/src/components/news/newsDetails/NewsDetails.tsx
@@ -177,7 +177,7 @@ class NewsDetails extends React.Component {
   }
 }
 
-NewsDetails.PropTypes = {
+NewsDetails.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/notifications/Notification.tsx
+++ b/src/components/notifications/Notification.tsx
@@ -198,7 +198,7 @@ class Notification extends React.Component<Props, State> {
   }
 }
 
-Notification.PropTypes = {
+Notification.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/pharmacy/Pharmacy.tsx
+++ b/src/components/pharmacy/Pharmacy.tsx
@@ -564,7 +564,7 @@ class Pharmacy extends React.Component<Props, State> {
   }
 }
 
-Pharmacy.PropTypes = {
+Pharmacy.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/settings/Setting.tsx
+++ b/src/components/settings/Setting.tsx
@@ -185,7 +185,7 @@ class Setting extends React.Component<Props, State> {
   }
 }
 
-Setting.PropTypes = {
+Setting.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/ward/Ward.tsx
+++ b/src/components/ward/Ward.tsx
@@ -713,7 +713,7 @@ class Ward extends React.Component {
   }
 }
 
-Ward.PropTypes = {
+Ward.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 


### PR DESCRIPTION
fix proptypes warning in console such as

```

Warning: Component <NAME> declared `PropTypes` instead of `propTypes`.
Did you misspell the property assignment?

```