### PR TITLE
Fix jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,13 @@ module.exports = {
   "roots": [
     "<rootDir>/src"
   ],
-  "setupTestFrameworkScriptFile": "<rootDir>/src/setup.tests.ts",
+  "setupFilesAfterEnv": ["<rootDir>/src/setup.tests.ts"],
   "transform": {
     "^.+\\.tsx?$": "ts-jest",
     "^.+\.(?!js|jsx|ts|tsx).*$": "jest-transform-stub" // stubs all not javascript files
+  },
+  "moduleNameMapper": {
+    ".*\\.(css|less|scss|sass)$": "<rootDir>/src/mocks/cssModule.js"
   },
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   "moduleFileExtensions": [
@@ -18,7 +21,7 @@ module.exports = {
   ],
   "globals": {
     "ts-jest": {
-      "tsConfig": "tsconfig.test.json",
+      "tsConfig": "<rootDir>/tsconfig.test.json",
       "diagnostics": {
         "warnOnly": true
       }

--- a/src/components/calendar/Calendario.tsx
+++ b/src/components/calendar/Calendario.tsx
@@ -329,7 +329,7 @@ class Calendario extends React.Component<Props, State> {
   }
 }
 
-Calendar.propTypes = {
+Calendario.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/mocks/cssModule.js
+++ b/src/mocks/cssModule.js
@@ -1,0 +1,1 @@
+module.exports = 'CSS_MODULE';


### PR DESCRIPTION
Make jest run:

    - remove deprecated setupTestFrameworkScriptFile key
    - add setupFilesAfterEnv key
    - add a css mock module to fix broken css imports
    - fix `TypeError: Cannot create property 'propTypes' on string ''` on `Calendario` component