### PR TITLE
Chore: Duplicate case specified

### DIFF
--- a/src/state/bills/reducer.ts
+++ b/src/state/bills/reducer.ts
@@ -10,6 +10,7 @@ import {
   GET_BILL_FAIL,
   SEARCH_BILL_LOADING,
   SEARCH_BILL_SUCCESS,
+  SEARCH_BILL_FAIL,
   PENDING_BILL_LOADING,
   PENDING_BILL_SUCCESS,
   PENDING_BILL_FAIL,
@@ -85,7 +86,7 @@ export default produce((draft: IBillsState, action: IAction<any, any>) => {
       break;
     }
 
-    case GET_BILL_FAIL: {
+    case SEARCH_BILL_FAIL: {
       draft.searchBills.status = "FAIL";
       draft.searchBills.error = action.error;
       break;


### PR DESCRIPTION
`GET_BILL_FAIL` case specified twice; the second one should be `SEARCH_BILL_FAIL`

Probably a cut-n-paste error.