### PR TITLE
OH2-49 | Add Admissions section e2e tests

### DIFF
--- a/cypress/integration/patient_details_activity/admissions.spec.js
+++ b/cypress/integration/patient_details_activity/admissions.spec.js
@@ -1,0 +1,64 @@
+const HOSTNAME = Cypress.env("HOSTNAME");
+const START_PATH_INPATIENT = `${HOSTNAME}/patients/details/1`;
+const START_PATH_OUTPATIENT = `${HOSTNAME}/patients/details/1234563`;
+
+describe("Patient Details / Admissions / Inpatient", () => {
+  before(() => {
+    cy.authenticate(START_PATH_INPATIENT);
+  });
+
+  it("should render the ui", () => {
+    cy.get("[class=patientDetails]");
+  });
+
+  it("should have a menu item for visits", () => {
+    cy.get("[class='patientDetails__main_menu']")
+      .contains("Admissions:")
+      .click();
+  });
+
+  it("should display an info box saying the patient is already admitted", () => {
+    cy.get("[class=patientAdmission__subtitle]").contains(
+      "The patient has already been admitted, here you will find the history of admissions. To resign, go to the dismission page."
+    );
+  });
+});
+
+describe("Patient Details / Admissions / Outpatient", () => {
+  before(() => {
+    cy.authenticate(START_PATH_OUTPATIENT);
+  });
+
+  it("should render the ui", () => {
+    cy.get("[class=patientDetails]");
+  });
+
+  it("should have a menu item for visits", () => {
+    cy.get("[class='patientDetails__main_menu']")
+      .contains("Admissions:")
+      .click();
+  });
+
+  it("should make it possible for the user to fill out the admission form to admit a patient", () => {
+    cy.get("[id=ward]").focus().clear().type("FEMALE WARDS").blur();
+    cy.get("[id=transUnit]").focus().clear().type("1").blur();
+    cy.get("[id=admDate]").focus().clear().type("03052022").blur();
+    cy.get("[id=admType]").focus().clear().type("SELF").blur();
+    cy.get("[id=diseaseIn]").focus().clear().type("Abortions").blur();
+    cy.get("[id=note]").focus().clear().type("fail").blur();
+  });
+
+  it("should display an error info box if the visit creation fails", () => {
+    cy.get("[class='submit_button']").click();
+
+    cy.get("div.infoBox").should("have.class", "error");
+  });
+
+  it("should show a confirmation dialog if the admission succeeds", () => {
+    cy.get("[id=note]").focus().clear().type("succeed").blur();
+    cy.get("[class='submit_button']").click();
+    cy.get("div.infoBox").should("not.exist");
+    cy.get("div.dialog__title").contains("Patient admitted");
+    cy.get("[class='return_button']").click();
+  });
+});

--- a/cypress/integration/patient_details_activity/visits.spec.js
+++ b/cypress/integration/patient_details_activity/visits.spec.js
@@ -2,7 +2,7 @@ const HOSTNAME = Cypress.env("HOSTNAME");
 const START_PATH_INPATIENT = `${HOSTNAME}/patients/details/1`;
 const START_PATH_OUTPATIENT = `${HOSTNAME}/patients/details/1234563`;
 
-describe("Patient Details / Visit - Inpatient", () => {
+describe("Patient Details / Visit / Inpatient", () => {
   before(() => {
     cy.authenticate(START_PATH_INPATIENT);
   });
@@ -15,7 +15,7 @@ describe("Patient Details / Visit - Inpatient", () => {
     cy.get("[class='patientDetails__main_menu']").contains("Visits:").click();
   });
 
-  it("Should make it possible for the user to fill out the form to add a new visit for an inpatient", () => {
+  it("should make it possible for the user to fill out the form to add a new visit for an inpatient", () => {
     cy.get("[id=ward]").focus().type("FEMALE WARDS").blur();
     cy.get("[id=date]").focus().type("03052022").blur();
     cy.get("[id=duration]").focus().type("100").blur();
@@ -28,7 +28,7 @@ describe("Patient Details / Visit - Inpatient", () => {
     cy.get("div.infoBox").should("have.class", "error");
   });
 
-  it("should show confirmation dialog if the visit creation succeeds", () => {
+  it("should show a confirmation dialog if the visit creation succeeds", () => {
     cy.get("[id=duration]").focus().clear().type("40").blur();
     cy.get("[class='submit_button']").click();
     cy.get("div.infoBox").should("not.exist");
@@ -37,7 +37,7 @@ describe("Patient Details / Visit - Inpatient", () => {
   });
 });
 
-describe("Patient Details / Visit - Outpatient", () => {
+describe("Patient Details / Visit / Outpatient", () => {
   before(() => {
     cy.authenticate(START_PATH_OUTPATIENT);
   });

--- a/src/mockServer/routes/admissions.js
+++ b/src/mockServer/routes/admissions.js
@@ -5,7 +5,7 @@ export const admissionRoutes = (server) => {
   server.namespace("/admissions", () => {
     server.post("/").intercept((req, res) => {
       const body = req.jsonBody();
-      switch (body.admDate) {
+      switch (body.note) {
         case "fail":
           res.status(400);
           break;
@@ -52,7 +52,7 @@ export const admissionRoutes = (server) => {
           res.body = null;
           break;
         default:
-          res.status(200).json(admissionDTO);
+          res.status(200).json({});
       }
     });
     server.post("/discharge").intercept((req, res) => {


### PR DESCRIPTION
This branch adds _e2e tests_ for the **Admissions** section of the **Patient Details Activity**. While doing this work, I noticed we call the endpoint `admissions/current` at the initialization of this section. It seems inappropriate though. If we are creating a new entry for **Admission**, we are not supposed to fill out the form fields with the data of a current **Admission** entry, because if a current **Admission** exists, we shouldn't see that form at all. I ask @SteveGT96 for feedback on this. If my guess is right, I'll open a task for fixing that surplus call.