### PR TITLE
Features/add docker development env

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./docker
+    environment:
+      GITHUB_ORG: intesys
+      OH_CORE_BRANCH: develop
+      OH_API_BRANCH: develop
+    ports:
+      - "8080:8080"
+    depends_on:
+      - database
+    networks:
+      - openhospital
+
+  database:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.database
+    image: oh-core_database:latest
+    environment:
+      GITHUB_ORG: intesys
+      OH_CORE_BRANCH: develop
+    ports:
+      - "3306:3306"
+    command: mysqld --sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION" --lower_case_table_names=1
+    networks:
+      - openhospital
+
+networks:
+  openhospital:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,10 +4,11 @@ services:
   backend:
     build:
       context: ./docker
-    environment:
-      GITHUB_ORG: intesys
-      OH_CORE_BRANCH: develop
-      OH_API_BRANCH: develop
+      dockerfile: Dockerfile.backend
+      args:
+        GITHUB_ORG: intesys
+        OH_CORE_BRANCH: staging3
+        OH_API_BRANCH: staging3
     ports:
       - "8080:8080"
     depends_on:
@@ -19,10 +20,9 @@ services:
     build:
       context: ./docker
       dockerfile: Dockerfile.database
-    image: oh-core_database:latest
-    environment:
-      GITHUB_ORG: intesys
-      OH_CORE_BRANCH: develop
+      args:
+        GITHUB_ORG: intesys
+        OH_CORE_BRANCH: staging3
     ports:
       - "3306:3306"
     command: mysqld --sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION" --lower_case_table_names=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM maven:3.8-jdk-8
+
+ENV GITHUB_ORG="intesys"
+ENV OH_CORE_BRANCH="develop"
+ENV OH_API_BRANCH="develop"
+
+WORKDIR /
+RUN git clone --depth=1 -b ${OH_CORE_BRANCH} https://github.com/${GITHUB_ORG}/openhospital-core.git
+WORKDIR /openhospital-core
+RUN mvn install
+
+WORKDIR /
+RUN git clone --depth=1 -b ${OH_API_BRANCH} https://github.com/${GITHUB_ORG}/openhospital-api.git
+WORKDIR /openhospital-api
+RUN mvn install
+
+CMD mvn spring-boot:run
+
+# RUN java -jar openhospital-api-0.0.2.jar

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,8 +1,8 @@
 FROM maven:3.8-jdk-8
 
-ENV GITHUB_ORG="intesys"
-ENV OH_CORE_BRANCH="develop"
-ENV OH_API_BRANCH="develop"
+ARG GITHUB_ORG
+ARG OH_CORE_BRANCH
+ARG OH_API_BRANCH
 
 WORKDIR /
 RUN git clone --depth=1 -b ${OH_CORE_BRANCH} https://github.com/${GITHUB_ORG}/openhospital-core.git
@@ -12,8 +12,8 @@ RUN mvn install
 WORKDIR /
 RUN git clone --depth=1 -b ${OH_API_BRANCH} https://github.com/${GITHUB_ORG}/openhospital-api.git
 WORKDIR /openhospital-api
+# Database connection must be changed in order to work in docker network
+RUN sed -i 's/localhost/database/g' src/main/resources/database.properties
 RUN mvn install
 
 CMD mvn spring-boot:run
-
-# RUN java -jar openhospital-api-0.0.2.jar

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -1,0 +1,36 @@
+FROM mariadb:10.2.40
+
+ENV GITHUB_ORG="intesys"
+ENV OH_CORE_BRANCH="develop"
+ENV MYSQL_DATABASE=oh
+ENV MYSQL_ROOT_PASSWORD=root
+ENV MYSQL_USER=isf
+ENV MYSQL_PASSWORD=isf123
+
+RUN apt-get update
+RUN apt-get install git -y
+RUN git clone --depth=1 -b ${OH_CORE_BRANCH} https://github.com/${GITHUB_ORG}/openhospital-core.git
+WORKDIR /openhospital-core
+
+EXPOSE 3306
+
+# RUN cp -R sql/ docker-entrypoint-initdb.d/
+ 
+RUN cp sql/step_01_create_structure.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_02_dump_menu.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_03_dump_default_data_en.sql /docker-entrypoint-initdb.d/
+#RUN cp sql/step_04_all_following_steps.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_05_update_menu_i18n.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_06_opd_extended.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_07_modifiche_matiri.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_08_int_restore_del_labrestype.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_09_update_agetype.sql /docker-entrypoint-initdb.d/
+RUN cp sql/step_1* /docker-entrypoint-initdb.d/
+RUN cp sql/step_2* /docker-entrypoint-initdb.d/
+RUN cp sql/step_3* /docker-entrypoint-initdb.d/
+RUN cp sql/step_4* /docker-entrypoint-initdb.d/
+RUN cp sql/step_5* /docker-entrypoint-initdb.d/
+RUN cp sql/step_6* /docker-entrypoint-initdb.d/
+RUN cp sql/step_7* /docker-entrypoint-initdb.d/
+RUN mkdir data_en
+RUN cp sql/data_en/* data_en/

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -1,7 +1,8 @@
 FROM mariadb:10.2.40
 
-ENV GITHUB_ORG="intesys"
-ENV OH_CORE_BRANCH="develop"
+ARG GITHUB_ORG
+ARG OH_CORE_BRANCH
+
 ENV MYSQL_DATABASE=oh
 ENV MYSQL_ROOT_PASSWORD=root
 ENV MYSQL_USER=isf
@@ -13,8 +14,6 @@ RUN git clone --depth=1 -b ${OH_CORE_BRANCH} https://github.com/${GITHUB_ORG}/op
 WORKDIR /openhospital-core
 
 EXPOSE 3306
-
-# RUN cp -R sql/ docker-entrypoint-initdb.d/
  
 RUN cp sql/step_01_create_structure.sql /docker-entrypoint-initdb.d/
 RUN cp sql/step_02_dump_menu.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Docker environment is currently broken due to an error occurring on openhospital-core and openhospital-api on branch `staging3`.

In order to run environment, just run `docker-compose up` and point api to localhost:8080

Once fixed, this branch can be merged.

---

The main purpose of this feature is to allow frontend developers to run the full openhospital stack locally, in order to test integration before deploying.