### PR TITLE
OH2-252 | Fix audit logging

### DIFF
--- a/src/generated/runtime.ts
+++ b/src/generated/runtime.ts
@@ -127,6 +127,7 @@ export class BaseAPI {
       headers,
       body: body instanceof FormData ? body : JSON.stringify(body),
       responseType: responseType ?? "json",
+      withCredentials: true,
     };
   };
 
@@ -200,6 +201,7 @@ export interface RequestOpts extends AjaxRequest {
   headers?: HttpHeaders;
   body?: HttpBody;
   responseType?: "json" | "blob" | "arraybuffer" | "text";
+  withCredentials?: boolean;
 }
 
 export interface ResponseOpts {


### PR DESCRIPTION
See OH2-252.

When generating API with command `npm run build:api` (or `openapi-generator generate -i api/oh.yaml -g typescript-rxjs -c openapi-generator.config.json -o src/generated/`) it overrides the `withCredentials` settings, which is - so far - important for the SessionAudit logging.

This should be avoided in the future. Nevertheless, there might be better ways to track users sessionId (e.g. claiming it in the JWT token)