### PR TITLE
chore: restrict billing utils to billing

### DIFF
--- a/src/components/accessories/billsRecap/billsMining.test.ts
+++ b/src/components/accessories/billsRecap/billsMining.test.ts
@@ -1,0 +1,36 @@
+import { combineData, sortAndSlice } from "./billsMining";
+
+describe("billsMining", () => {
+  describe("combineData", () => {
+    it("should correctly combine data", () => {
+      const input = { key1: "value1", key2: "value2" };
+      const output = combineData(input);
+
+      expect(output).toEqual(input);
+    });
+  });
+
+  describe("sortAndSlice", () => {
+    it("should sort", () => {
+      const input = { keyA: 1, keyB: 2, keyC: 3, keyD: 4 };
+      const output = sortAndSlice(input);
+      expect(output).toEqual({ keyD: 4, keyC: 3, keyB: 2, keyA: 1 });
+    });
+    it("should sort", () => {
+      const input = { keyA: 1, keyB: 1, keyC: 1, keyD: 3 };
+      const output = sortAndSlice(input);
+      expect(output).toEqual({ keyA: 1, keyB: 1, keyC: 1, keyD: 3 });
+    });
+    it("should slice", () => {
+      const input = Array.from({ length: 99 }, (_v, index) => index).reduce(
+        (acc, index) => {
+          acc[`key${index}`] = index;
+          return acc;
+        },
+        {} as Record<string, number>
+      );
+      const output = sortAndSlice(input);
+      expect(Object.keys(output).length).toBe(10);
+    });
+  });
+});

--- a/src/components/accessories/billsRecap/billsMining.ts
+++ b/src/components/accessories/billsRecap/billsMining.ts
@@ -1,10 +1,24 @@
 import moment from "moment";
 import { FullBillDTO } from "../../../generated";
-import {
-  combineData,
-  sortAndSlice,
-} from "../../../libraries/formatUtils/dataFormatting";
 import { IBillSummary } from "../../activities/billingActivity/types";
+
+
+export const combineData: any = (data: any) => {
+  return Object.entries(data).reduce(
+    (r, [k, v]) => ({
+      ...r,
+      [k]: v,
+    }),
+    {}
+  );
+};
+
+export const sortAndSlice: any = (data: any) => {
+  return Object.entries(data)
+    .sort(([, a], [, b]) => (b as number) - +(a as number))
+    .slice(0, 10)
+    .reduce((r, [k, v]) => ({ ...r, [k]: v }), {});
+};
 
 export const computeBillSummary = (
   bills: FullBillDTO[] = [],

--- a/src/libraries/formatUtils/dataFormatting.ts
+++ b/src/libraries/formatUtils/dataFormatting.ts
@@ -44,19 +44,3 @@ export const unformatRenderDate = (value: string) => {
     : undefined;
 };
 
-export const combineData: any = (data: any) => {
-  return Object.entries(data).reduce(
-    (r, [k, v]) => ({
-      ...r,
-      [k]: v,
-    }),
-    {}
-  );
-};
-
-export const sortAndSlice: any = (data: any) => {
-  return Object.entries(data)
-    .sort(([, a], [, b]) => (b as number) - +(a as number))
-    .slice(0, 10)
-    .reduce((r, [k, v]) => ({ ...r, [k]: v }), {});
-};


### PR DESCRIPTION
moving utils functions `combineData` and `sortAndSlice` into the billing folder as :
* their expected behaviour is not obvious
* they are only used in billsMining.ts

I also added tests up to my understanding of their behavious
