### PR TITLE
chore: fix Storybook build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage
 
 # production
 build
+storybook-static
 
 # misc
 .DS_Store

--- a/src/components/accessories/charts/pie/Piechart.stories.tsx
+++ b/src/components/accessories/charts/pie/Piechart.stories.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Chart, registerables } from "chart.js";
 
-Chart.register(...registerables);
-
 import { Piechart } from "./Piechart";
 import moment from "moment";
+
+Chart.register(...registerables);
 
 export default {
   title: "Charts/Piechart",


### PR DESCRIPTION
storybook wasn't building, here is a set of minor changes to have it run again

# How to test this
 *  On **develop** branch, run `npm run build-storybook`, it should fail.
 * Then checkout this branch and run `npm run build-storybook` again, it should build successfully.
