### PR TITLE
Fix local swagger url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can run a full OH2 stack locally using [Docker](https://www.docker.com/) (re
 Then you can access to:
 
 - OH2 react app: [localhost:3030](http://localhost:3030)
-- Swagger api spec: [localhost:8080/oh-api/swagger-ui.html](http://localhost:8080/oh-api/swagger-ui.html)
+- Swagger api spec: [localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
 - Phpmyadmin, for looking inside database: [localhost:9000](http://localhost:9000)
 
 ## How to publish on Web Server


### PR DESCRIPTION
The url stated in documentation returns a 404 error. It's now fixed