### PR TITLE
fix: i18n status in patientActivity menu

### DIFF
--- a/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
+++ b/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
@@ -261,7 +261,7 @@ const PatientDetailsActivity: FunctionComponent<TProps> = ({
                       {patient?.data?.status === PatientDTOStatusEnum.I ? (
                         <div className="patientDetails_status_wrapper patientDetails_status_in">
                           <h6>
-                            Status: <span>{t("patient.instatus")}</span>
+                          {t("patient.status")}: <span>{t("patient.instatus")}</span>
                             <div
                               className="patientDetails_status_button"
                               onClick={() => {
@@ -278,7 +278,7 @@ const PatientDetailsActivity: FunctionComponent<TProps> = ({
                       ) : (
                         <div className="patientDetails_status_wrapper patientDetails_status_out">
                           <h6>
-                            Status: <span>{t("patient.outstatus")}</span>
+                          {t("patient.status")}: <span>{t("patient.outstatus")}</span>
                             <div
                               className="patientDetails_status_button"
                               onClick={() => {

--- a/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
+++ b/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
@@ -261,7 +261,7 @@ const PatientDetailsActivity: FunctionComponent<TProps> = ({
                       {patient?.data?.status === PatientDTOStatusEnum.I ? (
                         <div className="patientDetails_status_wrapper patientDetails_status_in">
                           <h6>
-                            Status: <span>Inpatient</span>
+                            Status: <span>{t("patient.instatus")}</span>
                             <div
                               className="patientDetails_status_button"
                               onClick={() => {
@@ -278,7 +278,7 @@ const PatientDetailsActivity: FunctionComponent<TProps> = ({
                       ) : (
                         <div className="patientDetails_status_wrapper patientDetails_status_out">
                           <h6>
-                            Status: <span>Outpatient</span>
+                            Status: <span>{t("patient.outstatus")}</span>
                             <div
                               className="patientDetails_status_button"
                               onClick={() => {

--- a/src/components/activities/searchPatientActivity/PatientSearchItem.tsx
+++ b/src/components/activities/searchPatientActivity/PatientSearchItem.tsx
@@ -53,13 +53,13 @@ const PatientSearchItem: FunctionComponent<IPatientSearchItemProps> = ({
                   {patient?.status === PatientDTOStatusEnum.I ? (
                     <div className="patientDetails_status_wrapper patientDetails_status_in">
                       <h6>
-                        Status: <span>Inpatient</span>
+                      {t("patient.status")}: <span>{t("patient.instatus")}</span>
                       </h6>
                     </div>
                   ) : (
                     <div className="patientDetails_status_wrapper patientDetails_status_out">
                       <h6>
-                        Status: <span>Outpatient</span>
+                      {t("patient.status")}: <span>{t("patient.outstatus")}</span>
                       </h6>
                     </div>
                   )}

--- a/src/resources/i18n/de.json
+++ b/src/resources/i18n/de.json
@@ -161,7 +161,8 @@
     "updated": "Patient aktualisiert",
     "created": "Patient erstellt",
     "updatesuccessful": "Der Patient wurde erfolgreich bearbeitet.",
-    "createother": "Weiteren Patienten hinzufügen"
+    "createother": "Weiteren Patienten hinzufügen",
+    "status": "Status"
   },
   "opd": {
     "newopd": "Erstellen Sie einen neuen OPD-Besuch",

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -161,7 +161,8 @@
     "updated": "Patient updated",
     "created": "Patient created",
     "updatesuccessful": "The patient was edit successfully.",
-    "createother": "Add Another Patient"
+    "createother": "Add Another Patient",
+    "status": "Status"
   },
   "opd": {
     "newopd": "Create new OPD Visit",

--- a/src/resources/i18n/fr.json
+++ b/src/resources/i18n/fr.json
@@ -161,7 +161,8 @@
     "updated": "Mis à jour du patient",
     "created": "Patient créé",
     "updatesuccessful": "Le patient a été modifié avec succès.",
-    "createother": "Ajouter un autre patient"
+    "createother": "Ajouter un autre patient",
+    "status": "Statut"
   },
   "opd": {
     "newopd": "Créer une nouvelle visite OPD",

--- a/src/resources/i18n/it.json
+++ b/src/resources/i18n/it.json
@@ -155,7 +155,8 @@
     "updated": "Paziente aggiornato",
     "created": "Paziente creato",
     "updatesuccessful": "Il paziente è stato aggiornato correttamente.",
-    "createother": "Aggiungere un altro paziente"
+    "createother": "Aggiungere un altro paziente",
+    "status": "Stato"
   },
   "opd": {
     "newopd": "Inserisci una nuova visita ambulatoriale",

--- a/src/resources/i18n/sq.json
+++ b/src/resources/i18n/sq.json
@@ -161,7 +161,8 @@
     "updated": "Pacienti u aktualizua",
     "created": "Pacienti u krijua",
     "updatesuccessful": "Pacienti u redaktua me sukses.",
-    "createother": "Shto një Pacient të ri"
+    "createother": "Shto një Pacient të ri",
+    "status": "Statusi"
   },
   "opd": {
     "newopd": "Krijo nje vizitë Ambulatore",


### PR DESCRIPTION
Added internationalisation for statuses in patientActivity

before / after

![beforeafter](https://github.com/informatici/openhospital-ui/assets/597067/9804e8ed-f3f8-43e6-83cd-ebd38a0ab8d4)
