### PR TITLE
[OH2-274] buttons can accept dataCy

### DIFF
--- a/src/components/accessories/button/Button.tsx
+++ b/src/components/accessories/button/Button.tsx
@@ -9,6 +9,7 @@ const Button: FunctionComponent<IProps> = ({
   color = "primary",
   variant,
   disabled,
+  dataCy,
   onClick,
 }) => {
   return (
@@ -20,6 +21,7 @@ const Button: FunctionComponent<IProps> = ({
       disableElevation
       disabled={disabled}
       onClick={onClick}
+      data-cy={dataCy}
     >
       {children}
     </MaterialComponent>

--- a/src/components/accessories/button/types.ts
+++ b/src/components/accessories/button/types.ts
@@ -3,5 +3,6 @@ export interface IProps {
   variant?: "text" | "outlined" | "contained" | undefined;
   color?: "primary" | "inherit" | "secondary" | "default" | undefined;
   disabled?: boolean;
+  dataCy?: string;
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }


### PR DESCRIPTION
# What
See OH2-274.

`<Button />` now accepts `string?` property `dataCy` (see OH2-274).

# Why
In order to ease *end to end testing*, let's allow adding data-cy to buttons.
The data-cy attribute, introduced by @SteveGT96  in this pull request https://github.com/informatici/openhospital-ui/pull/566 should be applied easily on buttons so that actions do not depend from their text content (source: [cypress best practices](https://docs.cypress.io/guides/references/best-practices#Text-Content))

# Demo
![data-cy](https://github.com/informatici/openhospital-ui/assets/597067/b156ef38-c4ff-4812-903a-8b3ed60299a7)
