### PR TITLE
OH2-273 test(cypress): apply changes following-up to the update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,4 @@ jobs:
         with:
           record: false
           start: npm start
-          spec: cypress/e2e/**/*
-          env: host=localhost,port=3000
           wait-on: "http://localhost:3000"

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,13 +2,12 @@ import { defineConfig } from "cypress";
 import plugin from "./cypress/plugins";
 
 export default defineConfig({
-  env: {
-    HOSTNAME: "http://localhost:3000",
-  },
   e2e: {
+    baseUrl: "http://localhost:3000",
     setupNodeEvents(on, config) {
       plugin(on, config);
     },
+    specPattern: 'cypress/integrations/**/*.cy.ts',
     testIsolation: false,
     experimentalRunAllSpecs: true,
   },

--- a/cypress.d.ts
+++ b/cypress.d.ts
@@ -1,4 +1,4 @@
-import { mount } from 'cypress/react'
+import { mount } from "cypress/react";
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.

--- a/cypress/integrations/edit_patient_activity.cy.ts
+++ b/cypress/integrations/edit_patient_activity.cy.ts
@@ -1,8 +1,10 @@
+/// <reference types="cypress" />
+
 import initialValues from "../fixtures/editPatientInitialValues.json";
 
 type InitialValuesKeys = keyof typeof initialValues;
 
-const START_PATH = "http://localhost:3000/patients/details/72/edit";
+const START_PATH = "/patients/details/72/edit";
 
 describe("EditPatientActivity spec", () => {
   it("should render the ui", () => {
@@ -26,7 +28,10 @@ describe("EditPatientActivity spec", () => {
       id: `[id=${fieldName.toString()}]`,
     }));
     fields.forEach((field) => {
-      cy.get(field.id).should("have.value", initialValues[field.fieldName as InitialValuesKeys]);
+      cy.get(field.id).should(
+        "have.value",
+        initialValues[field.fieldName as InitialValuesKeys]
+      );
     });
   });
 
@@ -35,16 +40,16 @@ describe("EditPatientActivity spec", () => {
   });
 
   it("should allow the user to change the profile picture", () => {
+    cy.fixture("images/editPicture.jpg", null).as("editPicture");
     cy.dataCy("profile-picture")
       .find("img")
       .invoke("attr", "src")
       .then((firstSrc) => {
         const currentPicture = firstSrc;
 
-        cy.dataCy("profile-picture-input").attachFile(
-          "images/profilePicture.jpg",
-          { force: true }
-        );
+        cy.dataCy("profile-picture-input").selectFile("@editPicture", {
+          force: true,
+        });
         cy.get(".MuiDialogContent-root .MuiButton-containedPrimary").click();
         cy.wait(2000);
 

--- a/cypress/integrations/login_activity.cy.ts
+++ b/cypress/integrations/login_activity.cy.ts
@@ -1,6 +1,8 @@
+/// <reference types="cypress" />
+
 describe("LoginActivity spec", () => {
   it("should render the ui", () => {
-    cy.visit("http://localhost:3000/", {
+    cy.visit("/", {
       onBeforeLoad(w) {
         w.sessionStorage.clear();
       },

--- a/cypress/integrations/new_patient_activity.cy.ts
+++ b/cypress/integrations/new_patient_activity.cy.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 import initialValues from "../fixtures/newPatientInitialValues.json";
 
 const START_PATH = "http://localhost:3000/patients/new";
@@ -33,14 +35,15 @@ describe("NewPatientActivity spec", () => {
   });
 
   it("should allow the user to add and remove a profile picture", () => {
+    cy.fixture("images/profilePicture.jpg", null).as("profilePicture");
     cy.dataCy("profile-picture")
       .find("img")
       .invoke("attr", "src")
       .then((firstSrc) => {
         const placeholder = firstSrc;
 
-        cy.dataCy("profile-picture-input").attachFile(
-          "images/profilePicture.jpg",
+        cy.dataCy("profile-picture-input").selectFile(
+          "@profilePicture",
           { force: true }
         );
         cy.get(".MuiDialogContent-root .MuiButton-containedPrimary").click();

--- a/cypress/integrations/patient_details_activity/discharge.cy.ts
+++ b/cypress/integrations/patient_details_activity/discharge.cy.ts
@@ -1,6 +1,8 @@
+/// <reference types="cypress" />
+
 describe("Patient Details / Discharge", () => {
   before(() => {
-    cy.authenticate(`${Cypress.env("HOSTNAME")}/patients/details/1`);
+    cy.authenticate('/patients/details/1');
   });
 
   it("should render the ui", () => {

--- a/cypress/integrations/patient_details_activity/exams.cy.ts
+++ b/cypress/integrations/patient_details_activity/exams.cy.ts
@@ -1,6 +1,8 @@
+/// <reference types="cypress" />
+
 describe("Patient Details / Exams", () => {
   before(() => {
-    cy.authenticate(`${Cypress.env("HOSTNAME")}/patients/details/1`);
+    cy.authenticate('/patients/details/1');
   });
 
   it("should render the ui", () => {

--- a/cypress/integrations/patient_details_activity/visits.cy.ts
+++ b/cypress/integrations/patient_details_activity/visits.cy.ts
@@ -1,6 +1,7 @@
-const HOSTNAME = Cypress.env("HOSTNAME");
-const START_PATH_INPATIENT = `${HOSTNAME}/patients/details/2`;
-const START_PATH_OUTPATIENT = `${HOSTNAME}/patients/details/1234563`;
+/// <reference types="cypress" />
+
+const START_PATH_INPATIENT = '/patients/details/2';
+const START_PATH_OUTPATIENT = '/patients/details/1234563';
 
 //both inpatient and out-patient used the same opd form now!
 describe.skip("Patient Details / Visit - Inpatient", () => {

--- a/cypress/integrations/search_patient_activity.cy.ts
+++ b/cypress/integrations/search_patient_activity.cy.ts
@@ -1,4 +1,6 @@
-const START_PATH = "http://localhost:3000/patients/search";
+/// <reference types="cypress" />
+
+const START_PATH = "/patients/search";
 
 describe("SearchPatientActivity spec", () => {
   it("should render the ui", () => {


### PR DESCRIPTION
See OH2-273.
Depends on https://github.com/informatici/openhospital-ui/pull/573

# Context
[Following-up with](https://github.com/informatici/openhospital-ui/pull/561#discussion_r1497714459) the  cypress update up to 13.x, let’s normalize it’s integration with best practices and use the latest features such as:

# What
* Set up a [baseUrl](https://docs.cypress.io/guides/references/best-practices#Setting-a-Global-baseUrl)
* [rename](https://docs.cypress.io/guides/references/migration-guide) /cypress/e2e/ to /cypress/integrations/ (introduced in 10.x -> [cf doc](https://docs.cypress.io/guides/references/migration-guide))
* use cy.fixture with [selectFile](https://docs.cypress.io/api/commands/selectfile)

follow up all changes referenced in [the migration guide](https://docs.cypress.io/guides/references/migration-guide)

make sure ci ([in github actions](https://github.com/informatici/openhospital-ui/blob/develop/.github/workflows/ci.yml#L32)) stays in sync

![image](https://github.com/informatici/openhospital-ui/assets/597067/c7165ab4-54ea-425d-8f64-c0d47fd0bd95)
