### PR TITLE
fix(table): make sure Record<string, any> gets converted to a string

### DIFF
--- a/src/components/accessories/table/Table.tsx
+++ b/src/components/accessories/table/Table.tsx
@@ -295,9 +295,10 @@ const Table: FunctionComponent<IProps> = ({
             result = removeRowWhere(result, (row) =>
               filter.value === undefined
                 ? false
-                : !(row[field.key] as string)
-                    ?.toLowerCase()
-                    ?.includes(filter.value.toString().toLowerCase())
+                : !row[field.key]
+                    ?.toString()
+                    .toLowerCase()
+                    .includes(filter.value.toString().toLowerCase())
             );
             break;
 


### PR DESCRIPTION
Two things bothered me in the previous implementation
```typescript
!(row[field.key] as string)
  ?.toLowerCase()
  ?.includes(filter.value.toString().toLowerCase())
```

First `row[field.key]` is typed as `Record<string, any>` so if you want to be sure it's a string, use `row[field.key]?.toString()` and it won't throw if null or undefined.

Note that in JavaScript, if const `a = {b:null}`, `a.b?.toString()` will return …undefined ! just as `a.c?.toString()`

Secondly: the 2nd ? in `a.b?.toLowerCase()?.includes(whatever)` seems useless, because toLowerCase() will always return some string or throw, it shall never return null or undefined.

---

The proposed implementation is less likely to interpretation, and should not throw.