### PR TITLE
fix: prevent from crashing when patientContext isn't resolved yet

### DIFF
--- a/src/components/activities/patientDetailsActivityContent/DischargeDetailsActivityContent.tsx
+++ b/src/components/activities/patientDetailsActivityContent/DischargeDetailsActivityContent.tsx
@@ -14,7 +14,7 @@ const DischargeDetailsActivityContent: FunctionComponent = () => {
     <Fragment>
       <div className="patientDetails__content_header"></div>
       <div className="patientDetails__content_body">
-        {status.toString() === PatientDTOStatusEnum.O ? (
+        {status?.toString() === PatientDTOStatusEnum.O ? (
           <PatientDetailsContent
             title={t("patient.summary")}
             content={PatientSummary}


### PR DESCRIPTION
It happened while I was testing something else. In all other contexts, this is safely handled, but not here. So I am fixing it.

Other ocurences in the code where this exception is handled
* https://github.com/informatici/openhospital-ui/blob/develop/src/components/accessories/admission/PatientAdmission.tsx#L199
* https://github.com/informatici/openhospital-ui/blob/develop/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx#L261
* https://github.com/informatici/openhospital-ui/blob/develop/src/components/activities/searchPatientActivity/PatientSearchItem.tsx#L56
