### PR TITLE
ci: try to fix ci e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,4 @@ jobs:
           record: false
           start: npm start
           wait-on: "http://localhost:3000"
+          config-file: cypress.config.ts


### PR DESCRIPTION
Since https://github.com/informatici/openhospital-ui/pull/561 it seems that ci e2e jobs are failing.

error message says ([source](https://github.com/informatici/openhospital-ui/actions/runs/9210777728/job/25338565713#step:3:776))

```
You are attempting to use Cypress with an older config file: cypress.json
When you upgraded to Cypress v10.0 the config file was updated and moved to a new location: cypress.config.ts

You may need to update any CLI scripts to ensure that they are referring the new version. This would typically look something like:
"cypress open --config-file=cypress.config.ts"
```

we are trying to fix that