### PR TITLE
ci: align deploy e2e w/ ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,17 +32,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       # https://github.com/cypress-io/github-action
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v6
         with:
           record: false
           start: npm start
-          spec: cypress/integration/**/*
-          env: host=localhost,port=3000
           wait-on: "http://localhost:3000"
-
   deploy:
     needs: e2e
     runs-on: ubuntu-latest


### PR DESCRIPTION
following-up with https://github.com/informatici/openhospital-ui/pull/592

---

# Problem

Since https://github.com/informatici/openhospital-ui/pull/561 it seems that ci e2e jobs are failing when merging in `develop` (but not when running in a pull request)

The error message says ([source](https://github.com/informatici/openhospital-ui/actions/runs/9210777728/job/25338565713#step:3:776))

```
You are attempting to use Cypress with an older config file: cypress.json
When you upgraded to Cypress v10.0 the config file was updated and moved to a new location: cypress.config.ts

You may need to update any CLI scripts to ensure that they are referring the new version. This would typically look something like:
"cypress open --config-file=cypress.config.ts"
```

# Solution

It appears that by upgrading from `cypress-io/github-action@v2` to `cypress-io/github-action@v6` this shall be automatically handled. No need to be verbose here, just make sure we are running the latest version of cypress-io/github-action :-)

Let's align `ci.yml` and `deploy.yml`.