### PR TITLE
OH2-307 | Refactor api response type

### DIFF
--- a/src/components/accessories/admin/diseases/diseaseTable/DiseaseTable.tsx
+++ b/src/components/accessories/admin/diseases/diseaseTable/DiseaseTable.tsx
@@ -6,7 +6,7 @@ import { CircularProgress } from "@material-ui/core";
 import { useSelector } from "react-redux";
 import { IState } from "../../../../../types";
 import { DiseaseDTO } from "../../../../../generated";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 import classes from "./DiseaseTable.module.scss";
 import { CheckOutlined } from "@material-ui/icons";
 import { TFilterField } from "../../../table/filter/types";
@@ -67,7 +67,7 @@ export const DiseaseTable: FunctionComponent<IOwnProps> = ({ onEdit }) => {
 
   const { data, status, error } = useSelector<
     IState,
-    IApiResponse<DiseaseDTO[]>
+    ApiResponse<DiseaseDTO[]>
   >((state) => state.diseases.allDiseases);
 
   const handleEdit = (row: DiseaseDTO) => {

--- a/src/components/accessories/admin/exams/examsTable/ExamsTable.tsx
+++ b/src/components/accessories/admin/exams/examsTable/ExamsTable.tsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { getExams } from "../../../../../state/exams/actions";
 import { IState } from "../../../../../types";
 import { ExamDTO } from "../../../../../generated";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 import classes from "./ExamsTable.module.scss";
 
 export const ExamsTable = () => {
@@ -29,7 +29,7 @@ export const ExamsTable = () => {
   };
   const order = ["code", "type", "description", "procedure", "defaultResult"];
 
-  const { data, status, error } = useSelector<IState, IApiResponse<ExamDTO[]>>(
+  const { data, status, error } = useSelector<IState, ApiResponse<ExamDTO[]>>(
     (state) => state.exams.examList
   );
 

--- a/src/components/accessories/admin/operations/operationTable/OperationTable.tsx
+++ b/src/components/accessories/admin/operations/operationTable/OperationTable.tsx
@@ -6,7 +6,7 @@ import { CircularProgress } from "@material-ui/core";
 import { useSelector } from "react-redux";
 import { IState } from "../../../../../types";
 import { OperationDTO } from "../../../../../generated";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 import classes from "./OperationTable.module.scss";
 import { TFilterField } from "../../../table/filter/types";
 
@@ -62,7 +62,7 @@ export const OperationTable: FunctionComponent<IOwnProps> = ({
 
   const { data, status, error } = useSelector<
     IState,
-    IApiResponse<OperationDTO[]>
+    ApiResponse<OperationDTO[]>
   >((state) => state.operations.operationList);
 
   const handleEdit = (row: OperationDTO) => {

--- a/src/components/accessories/admin/suppliers/suppliersTable/SuppliersTable.tsx
+++ b/src/components/accessories/admin/suppliers/suppliersTable/SuppliersTable.tsx
@@ -6,7 +6,7 @@ import { CircularProgress } from "@material-ui/core";
 import { useDispatch, useSelector } from "react-redux";
 import { IState } from "../../../../../types";
 import { SupplierDTO } from "../../../../../generated";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 import { getSuppliers } from "../../../../../state/suppliers/actions";
 import { TFilterField } from "../../../table/filter/types";
 import classes from "./SuppliersTable.module.scss";
@@ -39,7 +39,7 @@ export const SuppliersTable = () => {
 
   const { data, status, error } = useSelector<
     IState,
-    IApiResponse<SupplierDTO[]>
+    ApiResponse<SupplierDTO[]>
   >((state) => state.suppliers.supplierList);
 
   const formatDataToDisplay = (data: SupplierDTO[]) => {

--- a/src/components/accessories/admin/users/usersTable/UsersTable.tsx
+++ b/src/components/accessories/admin/users/usersTable/UsersTable.tsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { getUsers } from "../../../../../state/users/actions";
 import { IState } from "../../../../../types";
 import { UserDTO } from "../../../../../generated";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 import classes from "./UsersTable.module.scss";
 
 export const UsersTable = () => {
@@ -27,7 +27,7 @@ export const UsersTable = () => {
   };
   const order = ["userName", "userGroupName", "desc"];
 
-  const { data, status, error } = useSelector<IState, IApiResponse<UserDTO[]>>(
+  const { data, status, error } = useSelector<IState, ApiResponse<UserDTO[]>>(
     (state) => state.users.userList
   );
 

--- a/src/components/accessories/admin/wards/editWard/EditWard.tsx
+++ b/src/components/accessories/admin/wards/editWard/EditWard.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { getInitialFields } from "../wardForm/consts";
 import { useDispatch, useSelector } from "react-redux";
 import { WardDTO } from "../../../../../generated";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 import { updateWard } from "../../../../../state/ward/actions";
 import { IState } from "../../../../../types";
 import { Navigate, useLocation, useParams } from "react-router";
@@ -15,7 +15,7 @@ export const EditWard = () => {
   const { t } = useTranslation();
   const { state }: { state: WardDTO | undefined } = useLocation();
   const { id } = useParams();
-  const update = useSelector<IState, IApiResponse<WardDTO>>(
+  const update = useSelector<IState, ApiResponse<WardDTO>>(
     (state) => state.wards.update
   );
 

--- a/src/components/accessories/admin/wards/newWard/NewWard.tsx
+++ b/src/components/accessories/admin/wards/newWard/NewWard.tsx
@@ -6,12 +6,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { WardDTO } from "../../../../../generated";
 import { createWard } from "../../../../../state/ward/actions";
 import { IState } from "../../../../../types";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 
 export const NewWard = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const create = useSelector<IState, IApiResponse<WardDTO>>(
+  const create = useSelector<IState, ApiResponse<WardDTO>>(
     (state) => state.wards.create
   );
 

--- a/src/components/accessories/admin/wards/wardTable/WardTable.tsx
+++ b/src/components/accessories/admin/wards/wardTable/WardTable.tsx
@@ -6,7 +6,7 @@ import { CircularProgress } from "@material-ui/core";
 import { useDispatch, useSelector } from "react-redux";
 import { IState } from "../../../../../types";
 import { WardDTO } from "../../../../../generated";
-import { IApiResponse } from "../../../../../state/types";
+import { ApiResponse } from "../../../../../state/types";
 import { CheckOutlined } from "@material-ui/icons";
 import classes from "./WardTable.module.scss";
 import ConfirmationDialog from "../../../confirmationDialog/ConfirmationDialog";
@@ -65,11 +65,11 @@ export const WardTable: FunctionComponent<IOwnProps> = ({
     { key: "opd", label: t("ward.opd"), type: "boolean" },
   ];
 
-  const { data, status, error } = useSelector<IState, IApiResponse<WardDTO[]>>(
+  const { data, status, error } = useSelector<IState, ApiResponse<WardDTO[]>>(
     (state) => state.wards.allWards
   );
 
-  const deleteWard = useSelector<IState, IApiResponse<boolean>>(
+  const deleteWard = useSelector<IState, ApiResponse<boolean>>(
     (state) => state.wards.delete
   );
 

--- a/src/components/activities/adminActivity/SideMenu/SideMenu.tsx
+++ b/src/components/activities/adminActivity/SideMenu/SideMenu.tsx
@@ -19,7 +19,7 @@ import { MenuItem } from "../../../accessories/menuItem";
 import { useSelector } from "react-redux";
 import { IState } from "../../../../types";
 import { HospitalDTO } from "../../../../generated";
-import { IApiResponse } from "../../../../state/types";
+import { ApiResponse } from "../../../../state/types";
 
 const SideMenu = () => {
   const { t } = useTranslation();
@@ -27,7 +27,7 @@ const SideMenu = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const hospital = useSelector<IState, IApiResponse<HospitalDTO>>(
+  const hospital = useSelector<IState, ApiResponse<HospitalDTO>>(
     (state) => state.hospital.getHospital
   );
 

--- a/src/components/activities/editPatientActivity/types.ts
+++ b/src/components/activities/editPatientActivity/types.ts
@@ -1,13 +1,13 @@
 import { PatientDTO } from "../../../generated";
 import { TUserCredentials } from "../../../state/main/types";
-import { IApiResponse } from "../../../state/types";
+import { ApiResponse } from "../../../state/types";
 
 export interface IStateProps {
   userCredentials: TUserCredentials;
   isLoading: boolean;
   hasSucceeded: boolean;
   hasFailed: boolean;
-  patient: IApiResponse<PatientDTO>;
+  patient: ApiResponse<PatientDTO>;
 }
 
 export interface IDispatchProps {

--- a/src/components/activities/patientDetailsActivity/types.ts
+++ b/src/components/activities/patientDetailsActivity/types.ts
@@ -1,10 +1,10 @@
 import { TUserCredentials } from "../../../state/main/types";
-import { IApiResponse } from "../../../state/types";
+import { ApiResponse } from "../../../state/types";
 import { PatientDTO } from "../../../generated";
 
 export interface IStateProps {
   userCredentials: TUserCredentials;
-  patient: IApiResponse<PatientDTO>;
+  patient: ApiResponse<PatientDTO>;
 }
 
 export interface IDispatchProps {

--- a/src/state/admissionTypes/initial.ts
+++ b/src/state/admissionTypes/initial.ts
@@ -1,5 +1,6 @@
 import { IAdmissionTypeState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IAdmissionTypeState = {
-  allAdmissionTypes: { status: "IDLE", data: [] },
+  allAdmissionTypes: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/admissionTypes/types.ts
+++ b/src/state/admissionTypes/types.ts
@@ -1,6 +1,6 @@
 import { AdmissionTypeDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IAdmissionTypeState = {
-  allAdmissionTypes: IApiResponse<Array<AdmissionTypeDTO>>;
+  allAdmissionTypes: ApiResponse<Array<AdmissionTypeDTO>>;
 };

--- a/src/state/admissions/initial.ts
+++ b/src/state/admissions/initial.ts
@@ -1,12 +1,13 @@
 import { IAdmissionsState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IAdmissionsState = {
-  createAdmission: { status: "IDLE" },
-  updateAdmission: { status: "IDLE" },
-  getAdmissions: { status: "IDLE", data: undefined },
-  getPatientAdmissions: { status: "IDLE", data: [] },
-  getDischarges: { status: "IDLE", data: undefined },
-  getAdmittedPatients: { status: "IDLE", data: [] },
-  currentAdmissionByPatientId: { status: "IDLE", data: undefined },
-  dischargePatient: { status: "IDLE" },
+  createAdmission: new ApiResponse({ status: "IDLE" }),
+  updateAdmission: new ApiResponse({ status: "IDLE" }),
+  getAdmissions: new ApiResponse({ status: "IDLE" }),
+  getPatientAdmissions: new ApiResponse({ status: "IDLE", data: [] }),
+  getDischarges: new ApiResponse({ status: "IDLE" }),
+  getAdmittedPatients: new ApiResponse({ status: "IDLE", data: [] }),
+  currentAdmissionByPatientId: new ApiResponse({ status: "IDLE" }),
+  dischargePatient: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/admissions/types.ts
+++ b/src/state/admissions/types.ts
@@ -3,15 +3,15 @@ import {
   AdmittedPatientDTO,
   PageAdmissionDTO,
 } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IAdmissionsState = {
-  createAdmission: IApiResponse<AdmissionDTO>;
-  updateAdmission: IApiResponse<AdmissionDTO>;
-  getAdmissions: IApiResponse<PageAdmissionDTO>;
-  getDischarges: IApiResponse<PageAdmissionDTO>;
-  getPatientAdmissions: IApiResponse<Array<AdmissionDTO>>;
-  getAdmittedPatients: IApiResponse<Array<AdmittedPatientDTO>>;
-  currentAdmissionByPatientId: IApiResponse<AdmissionDTO>;
-  dischargePatient: IApiResponse<AdmissionDTO>;
+  createAdmission: ApiResponse<AdmissionDTO>;
+  updateAdmission: ApiResponse<AdmissionDTO>;
+  getAdmissions: ApiResponse<PageAdmissionDTO>;
+  getDischarges: ApiResponse<PageAdmissionDTO>;
+  getPatientAdmissions: ApiResponse<Array<AdmissionDTO>>;
+  getAdmittedPatients: ApiResponse<Array<AdmittedPatientDTO>>;
+  currentAdmissionByPatientId: ApiResponse<AdmissionDTO>;
+  dischargePatient: ApiResponse<AdmissionDTO>;
 };

--- a/src/state/ageTypes/initial.ts
+++ b/src/state/ageTypes/initial.ts
@@ -1,5 +1,6 @@
 import { IAgeTypeState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IAgeTypeState = {
-  getAllAgeTypes: { status: "IDLE", data: [] },
+  getAllAgeTypes: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/ageTypes/types.ts
+++ b/src/state/ageTypes/types.ts
@@ -1,6 +1,6 @@
 import { AgeTypeDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IAgeTypeState = {
-  getAllAgeTypes: IApiResponse<Array<AgeTypeDTO>>;
+  getAllAgeTypes: ApiResponse<Array<AgeTypeDTO>>;
 };

--- a/src/state/bills/initial.ts
+++ b/src/state/bills/initial.ts
@@ -1,14 +1,15 @@
 import { IBillsState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IBillsState = {
-  newBill: { status: "IDLE" },
-  updateBill: { status: "IDLE" },
-  getBill: { status: "IDLE", data: undefined },
-  searchBills: { status: "IDLE", data: [] },
-  getPendingBills: { status: "IDLE", data: [] },
-  searchPayments: { status: "IDLE", data: [] },
-  delete: { status: "IDLE" },
-  payBill: { status: "IDLE" },
-  closeBill: { status: "IDLE" },
-  getBillsByYear: { status: "IDLE", data: [] },
+  newBill: new ApiResponse({ status: "IDLE" }),
+  updateBill: new ApiResponse({ status: "IDLE" }),
+  getBill: new ApiResponse({ status: "IDLE" }),
+  searchBills: new ApiResponse({ status: "IDLE", data: [] }),
+  getPendingBills: new ApiResponse({ status: "IDLE", data: [] }),
+  searchPayments: new ApiResponse({ status: "IDLE", data: [] }),
+  delete: new ApiResponse({ status: "IDLE" }),
+  payBill: new ApiResponse({ status: "IDLE" }),
+  closeBill: new ApiResponse({ status: "IDLE" }),
+  getBillsByYear: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/bills/types.ts
+++ b/src/state/bills/types.ts
@@ -1,16 +1,16 @@
 import { BillDTO, BillPaymentsDTO } from "../../generated";
 import { FullBillDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IBillsState = {
-  newBill: IApiResponse<FullBillDTO>;
-  updateBill: IApiResponse<FullBillDTO>;
-  getBill: IApiResponse<BillDTO>;
-  searchBills: IApiResponse<FullBillDTO[]>;
-  getPendingBills: IApiResponse<FullBillDTO[]>;
-  searchPayments: IApiResponse<BillPaymentsDTO[]>;
-  delete: IApiResponse<void>;
-  payBill: IApiResponse<FullBillDTO>;
-  closeBill: IApiResponse<FullBillDTO>;
-  getBillsByYear: IApiResponse<FullBillDTO[]>;
+  newBill: ApiResponse<FullBillDTO>;
+  updateBill: ApiResponse<FullBillDTO>;
+  getBill: ApiResponse<BillDTO>;
+  searchBills: ApiResponse<FullBillDTO[]>;
+  getPendingBills: ApiResponse<FullBillDTO[]>;
+  searchPayments: ApiResponse<BillPaymentsDTO[]>;
+  delete: ApiResponse<void>;
+  payBill: ApiResponse<FullBillDTO>;
+  closeBill: ApiResponse<FullBillDTO>;
+  getBillsByYear: ApiResponse<FullBillDTO[]>;
 };

--- a/src/state/dashboard/initial.ts
+++ b/src/state/dashboard/initial.ts
@@ -1,4 +1,5 @@
 import { IDashboardState } from "./types";
+import { ApiResponse } from "../types";
 import { getCachedPeriod } from "../../components/accessories/dashboard/dashboardContent/filter/consts";
 
 export const initial: IDashboardState = {

--- a/src/state/dischargeTypes/initial.ts
+++ b/src/state/dischargeTypes/initial.ts
@@ -1,5 +1,6 @@
 import { IDischargeTypeState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IDischargeTypeState = {
-  allDischargeTypes: { status: "IDLE", data: [] },
+  allDischargeTypes: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/dischargeTypes/types.ts
+++ b/src/state/dischargeTypes/types.ts
@@ -1,6 +1,6 @@
 import { DischargeTypeDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IDischargeTypeState = {
-  allDischargeTypes: IApiResponse<Array<DischargeTypeDTO>>;
+  allDischargeTypes: ApiResponse<Array<DischargeTypeDTO>>;
 };

--- a/src/state/diseaseTypes/initial.ts
+++ b/src/state/diseaseTypes/initial.ts
@@ -1,5 +1,6 @@
 import { IDiseaseTypeState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IDiseaseTypeState = {
-  getDiseaseTypes: { status: "IDLE", data: [] },
+  getDiseaseTypes: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/diseaseTypes/types.ts
+++ b/src/state/diseaseTypes/types.ts
@@ -1,6 +1,6 @@
 import { DiseaseTypeDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IDiseaseTypeState = {
-  getDiseaseTypes: IApiResponse<Array<DiseaseTypeDTO>>;
+  getDiseaseTypes: ApiResponse<Array<DiseaseTypeDTO>>;
 };

--- a/src/state/diseases/initial.ts
+++ b/src/state/diseases/initial.ts
@@ -1,8 +1,9 @@
 import { IDiseaseState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IDiseaseState = {
-  allDiseases: { status: "IDLE", data: [] },
-  diseasesOpd: { status: "IDLE", data: [] },
-  diseasesIpdIn: { status: "IDLE", data: [] },
-  diseasesIpdOut: { status: "IDLE", data: [] },
+  allDiseases: new ApiResponse({ status: "IDLE", data: [] }),
+  diseasesOpd: new ApiResponse({ status: "IDLE", data: [] }),
+  diseasesIpdIn: new ApiResponse({ status: "IDLE", data: [] }),
+  diseasesIpdOut: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/diseases/types.ts
+++ b/src/state/diseases/types.ts
@@ -1,9 +1,9 @@
 import { DiseaseDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IDiseaseState = {
-  allDiseases: IApiResponse<Array<DiseaseDTO>>;
-  diseasesOpd: IApiResponse<Array<DiseaseDTO>>;
-  diseasesIpdIn: IApiResponse<Array<DiseaseDTO>>;
-  diseasesIpdOut: IApiResponse<Array<DiseaseDTO>>;
+  allDiseases: ApiResponse<Array<DiseaseDTO>>;
+  diseasesOpd: ApiResponse<Array<DiseaseDTO>>;
+  diseasesIpdIn: ApiResponse<Array<DiseaseDTO>>;
+  diseasesIpdOut: ApiResponse<Array<DiseaseDTO>>;
 };

--- a/src/state/examTypes/initial.ts
+++ b/src/state/examTypes/initial.ts
@@ -1,5 +1,6 @@
 import { IExamTypeState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IExamTypeState = {
-  getExamTypes: { status: "IDLE", data: [] },
+  getExamTypes: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/examTypes/types.ts
+++ b/src/state/examTypes/types.ts
@@ -1,6 +1,6 @@
 import { ExamTypeDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IExamTypeState = {
-  getExamTypes: IApiResponse<Array<ExamTypeDTO>>;
+  getExamTypes: ApiResponse<Array<ExamTypeDTO>>;
 };

--- a/src/state/examinations/initial.ts
+++ b/src/state/examinations/initial.ts
@@ -1,10 +1,11 @@
 import { IExaminationsState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IExaminationsState = {
-  createExamination: { status: "IDLE" },
-  updateExamination: { status: "IDLE" },
-  getDefaultPatientExamination: { status: "IDLE" },
-  getLastByPatientId: { status: "IDLE" },
-  examinationsByPatientId: { status: "IDLE", data: [] },
-  deleteExamination: { status: "IDLE" },
+  createExamination: new ApiResponse({ status: "IDLE" }),
+  updateExamination: new ApiResponse({ status: "IDLE" }),
+  getDefaultPatientExamination: new ApiResponse({ status: "IDLE" }),
+  getLastByPatientId: new ApiResponse({ status: "IDLE" }),
+  examinationsByPatientId: new ApiResponse({ status: "IDLE", data: [] }),
+  deleteExamination: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/examinations/types.ts
+++ b/src/state/examinations/types.ts
@@ -1,11 +1,11 @@
 import { PatientExaminationDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IExaminationsState = {
-  createExamination: IApiResponse<PatientExaminationDTO>;
-  updateExamination: IApiResponse<PatientExaminationDTO>;
-  getDefaultPatientExamination: IApiResponse<PatientExaminationDTO>;
-  getLastByPatientId: IApiResponse<PatientExaminationDTO>;
-  examinationsByPatientId: IApiResponse<Array<PatientExaminationDTO>>;
-  deleteExamination: IApiResponse<null>;
+  createExamination: ApiResponse<PatientExaminationDTO>;
+  updateExamination: ApiResponse<PatientExaminationDTO>;
+  getDefaultPatientExamination: ApiResponse<PatientExaminationDTO>;
+  getLastByPatientId: ApiResponse<PatientExaminationDTO>;
+  examinationsByPatientId: ApiResponse<Array<PatientExaminationDTO>>;
+  deleteExamination: ApiResponse<null>;
 };

--- a/src/state/exams/initial.ts
+++ b/src/state/exams/initial.ts
@@ -1,7 +1,7 @@
-import { ExamDTO, ExamRowDTO } from "../../generated";
 import { IExamState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IExamState = {
-  examList: { status: "IDLE", data: new Array<ExamDTO>() },
-  examRowsByExamCode: { status: "IDLE", data: new Array<ExamRowDTO>() },
+  examList: new ApiResponse({ status: "IDLE", data: [] }),
+  examRowsByExamCode: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/exams/types.ts
+++ b/src/state/exams/types.ts
@@ -1,7 +1,7 @@
 import { ExamDTO, ExamRowDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IExamState = {
-  examList: IApiResponse<Array<ExamDTO>>;
-  examRowsByExamCode: IApiResponse<Array<ExamRowDTO>>;
+  examList: ApiResponse<Array<ExamDTO>>;
+  examRowsByExamCode: ApiResponse<Array<ExamRowDTO>>;
 };

--- a/src/state/hospital/initial.ts
+++ b/src/state/hospital/initial.ts
@@ -1,5 +1,6 @@
 import { IHospitalState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IHospitalState = {
-  getHospital: { status: "IDLE" },
+  getHospital: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/hospital/types.ts
+++ b/src/state/hospital/types.ts
@@ -1,6 +1,6 @@
 import { HospitalDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IHospitalState = {
-  getHospital: IApiResponse<HospitalDTO>;
+  getHospital: ApiResponse<HospitalDTO>;
 };

--- a/src/state/laboratories/initial.ts
+++ b/src/state/laboratories/initial.ts
@@ -1,15 +1,16 @@
 import { ILaboratoriesState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: ILaboratoriesState = {
-  createLab: { status: "IDLE" },
-  createLabRequest: { status: "IDLE" },
-  deleteLab: { status: "IDLE" },
-  cancelLab: { status: "IDLE" },
-  updateLab: { status: "IDLE" },
-  materials: { status: "IDLE", data: [] },
-  labsByPatientId: { status: "IDLE", data: [] },
-  labsRequestByPatientId: { status: "IDLE", data: [] },
-  getLabByCode: { status: "IDLE", data: null },
-  getLabWithRowsByCode: { status: "IDLE", data: null },
-  searchLabs: { status: "IDLE" },
+  createLab: new ApiResponse({ status: "IDLE" }),
+  createLabRequest: new ApiResponse({ status: "IDLE" }),
+  deleteLab: new ApiResponse({ status: "IDLE" }),
+  cancelLab: new ApiResponse({ status: "IDLE" }),
+  updateLab: new ApiResponse({ status: "IDLE" }),
+  materials: new ApiResponse({ status: "IDLE", data: [] }),
+  labsByPatientId: new ApiResponse({ status: "IDLE", data: [] }),
+  labsRequestByPatientId: new ApiResponse({ status: "IDLE", data: [] }),
+  getLabByCode: new ApiResponse({ status: "IDLE" }),
+  getLabWithRowsByCode: new ApiResponse({ status: "IDLE" }),
+  searchLabs: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/laboratories/types.ts
+++ b/src/state/laboratories/types.ts
@@ -3,18 +3,18 @@ import {
   LabWithRowsDTO,
   PageLabWithRowsDTO,
 } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type ILaboratoriesState = {
-  createLab: IApiResponse<LabWithRowsDTO>;
-  createLabRequest: IApiResponse<LaboratoryDTO>;
-  updateLab: IApiResponse<LabWithRowsDTO>;
-  deleteLab: IApiResponse<LaboratoryDTO>;
-  cancelLab: IApiResponse<LaboratoryDTO>;
-  materials: IApiResponse<Array<string>>;
-  labsByPatientId: IApiResponse<Array<LabWithRowsDTO>>;
-  labsRequestByPatientId: IApiResponse<Array<LaboratoryDTO>>;
-  getLabByCode: IApiResponse<LaboratoryDTO | null>;
-  getLabWithRowsByCode: IApiResponse<LabWithRowsDTO | null>;
-  searchLabs: IApiResponse<PageLabWithRowsDTO | null>;
+  createLab: ApiResponse<LabWithRowsDTO>;
+  createLabRequest: ApiResponse<LaboratoryDTO>;
+  updateLab: ApiResponse<LabWithRowsDTO>;
+  deleteLab: ApiResponse<LaboratoryDTO>;
+  cancelLab: ApiResponse<LaboratoryDTO>;
+  materials: ApiResponse<Array<string>>;
+  labsByPatientId: ApiResponse<Array<LabWithRowsDTO>>;
+  labsRequestByPatientId: ApiResponse<Array<LaboratoryDTO>>;
+  getLabByCode: ApiResponse<LaboratoryDTO | null>;
+  getLabWithRowsByCode: ApiResponse<LabWithRowsDTO | null>;
+  searchLabs: ApiResponse<PageLabWithRowsDTO | null>;
 };

--- a/src/state/layouts/initial.ts
+++ b/src/state/layouts/initial.ts
@@ -1,9 +1,10 @@
 import { ILayoutsState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: ILayoutsState = {
-  saveLayouts: { status: "IDLE" },
-  getLayouts: { status: "IDLE" },
-  resetLayouts: { status: "IDLE" },
+  saveLayouts: new ApiResponse({ status: "IDLE" }),
+  getLayouts: new ApiResponse({ status: "IDLE" }),
+  resetLayouts: new ApiResponse({ status: "IDLE" }),
   toolbox: {},
   layouts: {},
   breakpoint: "md",

--- a/src/state/layouts/types.ts
+++ b/src/state/layouts/types.ts
@@ -1,12 +1,12 @@
 import { Layouts } from "react-grid-layout";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 import { UserSettingDTO } from "../../generated";
 
 /** @todo set good types */
 export type ILayoutsState = {
-  saveLayouts: IApiResponse<UserSettingDTO>;
-  getLayouts: IApiResponse<UserSettingDTO>;
-  resetLayouts: IApiResponse<boolean>;
+  saveLayouts: ApiResponse<UserSettingDTO>;
+  getLayouts: ApiResponse<UserSettingDTO>;
+  resetLayouts: ApiResponse<boolean>;
   breakpoint: string;
   layouts: Layouts;
   toolbox: Layouts;

--- a/src/state/main/initial.ts
+++ b/src/state/main/initial.ts
@@ -1,16 +1,17 @@
 import { IMainState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IMainState = {
-  authentication: {
+  authentication: new ApiResponse({
     status: "IDLE",
-  },
-  logout: {
+  }),
+  logout: new ApiResponse({
     status: "IDLE",
-  },
-  forgotpassword: {
+  }),
+  forgotpassword: new ApiResponse({
     status: "IDLE",
-  },
-  settings: {
+  }),
+  settings: new ApiResponse({
     status: "IDLE",
-  },
+  }),
 };

--- a/src/state/main/types.ts
+++ b/src/state/main/types.ts
@@ -1,7 +1,7 @@
 import { UserSettingDTO } from "../../generated";
 import { LoginResponse } from "../../generated/models/LoginResponse";
 import { TPermission } from "../../types";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type TUserCredentials = LoginResponse | undefined;
 
@@ -10,8 +10,8 @@ export interface IAuthentication extends LoginResponse {
 }
 
 export interface IMainState {
-  authentication: IApiResponse<IAuthentication>;
-  logout: IApiResponse<void>;
-  forgotpassword: IApiResponse<void>;
-  settings: IApiResponse<UserSettingDTO[]>;
+  authentication: ApiResponse<IAuthentication>;
+  logout: ApiResponse<void>;
+  forgotpassword: ApiResponse<void>;
+  settings: ApiResponse<UserSettingDTO[]>;
 }

--- a/src/state/medicals/initial.ts
+++ b/src/state/medicals/initial.ts
@@ -1,6 +1,9 @@
-import { MedicalDTO } from "../../generated";
 import { IMedicalState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IMedicalState = {
-  medicalsOrderByName: { status: "IDLE", data: new Array<MedicalDTO>() },
+  medicalsOrderByName: new ApiResponse({
+    status: "IDLE",
+    data: [],
+  }),
 };

--- a/src/state/medicals/types.ts
+++ b/src/state/medicals/types.ts
@@ -1,6 +1,6 @@
 import { MedicalDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IMedicalState = {
-  medicalsOrderByName: IApiResponse<Array<MedicalDTO>>;
+  medicalsOrderByName: ApiResponse<Array<MedicalDTO>>;
 };

--- a/src/state/opds/initial.ts
+++ b/src/state/opds/initial.ts
@@ -1,10 +1,11 @@
 import { IOpdState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IOpdState = {
-  createOpd: { status: "IDLE" },
-  updateOpd: { status: "IDLE" },
-  getOpds: { status: "IDLE", data: [] },
-  lastOpd: { status: "IDLE", data: undefined },
-  searchOpds: { status: "IDLE" },
-  deleteOpd: { status: "IDLE" },
+  createOpd: new ApiResponse({ status: "IDLE" }),
+  updateOpd: new ApiResponse({ status: "IDLE" }),
+  getOpds: new ApiResponse({ status: "IDLE", data: [] }),
+  lastOpd: new ApiResponse({ status: "IDLE" }),
+  searchOpds: new ApiResponse({ status: "IDLE" }),
+  deleteOpd: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/opds/types.ts
+++ b/src/state/opds/types.ts
@@ -1,11 +1,11 @@
 import { OpdDTO, OpdWithOperationRowDTO, PageOpdDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IOpdState = {
-  getOpds: IApiResponse<Array<OpdWithOperationRowDTO>>;
-  lastOpd: IApiResponse<OpdDTO>;
-  searchOpds: IApiResponse<PageOpdDTO>;
-  createOpd: IApiResponse<OpdWithOperationRowDTO>;
-  updateOpd: IApiResponse<OpdWithOperationRowDTO>;
-  deleteOpd: IApiResponse<null>;
+  getOpds: ApiResponse<Array<OpdWithOperationRowDTO>>;
+  lastOpd: ApiResponse<OpdDTO>;
+  searchOpds: ApiResponse<PageOpdDTO>;
+  createOpd: ApiResponse<OpdWithOperationRowDTO>;
+  updateOpd: ApiResponse<OpdWithOperationRowDTO>;
+  deleteOpd: ApiResponse<null>;
 };

--- a/src/state/operationTypes/initial.ts
+++ b/src/state/operationTypes/initial.ts
@@ -1,5 +1,6 @@
 import { IOperationTypeState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IOperationTypeState = {
-  getOperationTypes: { status: "IDLE", data: [] },
+  getOperationTypes: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/operationTypes/types.ts
+++ b/src/state/operationTypes/types.ts
@@ -1,6 +1,6 @@
 import { OperationTypeDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IOperationTypeState = {
-  getOperationTypes: IApiResponse<Array<OperationTypeDTO>>;
+  getOperationTypes: ApiResponse<Array<OperationTypeDTO>>;
 };

--- a/src/state/operations/initial.ts
+++ b/src/state/operations/initial.ts
@@ -1,10 +1,19 @@
-import { OperationDTO, OperationRowDTO } from "../../generated";
 import { IOperationState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IOperationState = {
-  operationList: { status: "IDLE", data: new Array<OperationDTO>() },
-  createOperationRow: { status: "IDLE" },
-  updateOperationRow: { status: "IDLE" },
-  deleteOperationRow: { status: "IDLE" },
-  operationRowsByQdmt: { status: "IDLE", data: new Array<OperationRowDTO>() },
+  operationList: new ApiResponse({
+    status: "IDLE",
+    data: [],
+  }),
+  createOperationRow: new ApiResponse({ status: "IDLE" }),
+  updateOperationRow: new ApiResponse({ status: "IDLE" }),
+  deleteOperationRow: new ApiResponse({ status: "IDLE" }),
+  operationRowsByQdmt: new ApiResponse({
+    status: "IDLE",
+    data: [],
+  }),
+  create: new ApiResponse({ status: "IDLE" }),
+  update: new ApiResponse({ status: "IDLE" }),
+  delete: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/operations/types.ts
+++ b/src/state/operations/types.ts
@@ -1,10 +1,13 @@
 import { OperationDTO, OperationRowDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IOperationState = {
-  operationList: IApiResponse<Array<OperationDTO>>;
-  createOperationRow: IApiResponse<OperationRowDTO>;
-  updateOperationRow: IApiResponse<OperationRowDTO>;
-  deleteOperationRow: IApiResponse<OperationRowDTO>;
-  operationRowsByQdmt: IApiResponse<Array<OperationRowDTO>>;
+  operationList: ApiResponse<Array<OperationDTO>>;
+  createOperationRow: ApiResponse<OperationRowDTO>;
+  updateOperationRow: ApiResponse<OperationRowDTO>;
+  deleteOperationRow: ApiResponse<OperationRowDTO>;
+  operationRowsByQdmt: ApiResponse<Array<OperationRowDTO>>;
+  create: ApiResponse<OperationDTO>;
+  update: ApiResponse<OperationDTO>;
+  delete: ApiResponse<boolean>;
 };

--- a/src/state/patients/initial.ts
+++ b/src/state/patients/initial.ts
@@ -1,10 +1,11 @@
 import { IPatientsState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IPatientsState = {
-  createPatient: { status: "IDLE" },
-  searchResults: { status: "IDLE", data: [] },
-  selectedPatient: { status: "IDLE", data: undefined },
-  updatePatient: { status: "IDLE" },
-  getCities: { status: "IDLE", data: [] },
-  getPatients: { status: "IDLE" },
+  createPatient: new ApiResponse({ status: "IDLE" }),
+  searchResults: new ApiResponse({ status: "IDLE", data: [] }),
+  selectedPatient: new ApiResponse({ status: "IDLE" }),
+  updatePatient: new ApiResponse({ status: "IDLE" }),
+  getCities: new ApiResponse({ status: "IDLE", data: [] }),
+  getPatients: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/patients/types.ts
+++ b/src/state/patients/types.ts
@@ -1,11 +1,11 @@
 import { PagePatientDTO, PatientDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IPatientsState = {
-  createPatient: IApiResponse<PatientDTO>;
-  searchResults: IApiResponse<Array<PatientDTO>>;
-  selectedPatient: IApiResponse<PatientDTO>;
-  updatePatient: IApiResponse<PatientDTO>;
-  getCities: IApiResponse<Array<string>>;
-  getPatients: IApiResponse<PagePatientDTO>;
+  createPatient: ApiResponse<PatientDTO>;
+  searchResults: ApiResponse<Array<PatientDTO>>;
+  selectedPatient: ApiResponse<PatientDTO>;
+  updatePatient: ApiResponse<PatientDTO>;
+  getCities: ApiResponse<Array<string>>;
+  getPatients: ApiResponse<PagePatientDTO>;
 };

--- a/src/state/prices/initial.ts
+++ b/src/state/prices/initial.ts
@@ -1,6 +1,7 @@
 import { IPricesState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IPricesState = {
-  getPrices: { status: "IDLE", data: [] },
-  getPriceLists: { status: "IDLE", data: [] },
+  getPrices: new ApiResponse({ status: "IDLE", data: [] }),
+  getPriceLists: new ApiResponse({ status: "IDLE", data: [] }),
 };

--- a/src/state/prices/types.ts
+++ b/src/state/prices/types.ts
@@ -1,8 +1,8 @@
 import { PriceDTO } from "../../generated/models/PriceDTO";
 import { PriceListDTO } from "../../generated/models/PriceListDTO";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IPricesState = {
-  getPrices: IApiResponse<Array<PriceDTO>>;
-  getPriceLists: IApiResponse<Array<PriceListDTO>>;
+  getPrices: ApiResponse<Array<PriceDTO>>;
+  getPriceLists: ApiResponse<Array<PriceListDTO>>;
 };

--- a/src/state/summary/initial.ts
+++ b/src/state/summary/initial.ts
@@ -1,5 +1,9 @@
+import { ApiResponse } from "../types";
 import { ISummaryState, SummaryDataType } from "./types";
 
 export const initial: ISummaryState = {
-  summaryApisCall: { data: new Array<SummaryDataType>(), status: "IDLE" },
+  summaryApisCall: new ApiResponse({
+    data: new Array<SummaryDataType>(),
+    status: "IDLE",
+  }),
 };

--- a/src/state/summary/types.ts
+++ b/src/state/summary/types.ts
@@ -1,7 +1,7 @@
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type ISummaryState = {
-  summaryApisCall: IApiResponse<Array<SummaryDataType>>;
+  summaryApisCall: ApiResponse<Array<SummaryDataType>>;
 };
 
 export type SummaryDataType = {

--- a/src/state/suppliers/initial.ts
+++ b/src/state/suppliers/initial.ts
@@ -1,6 +1,9 @@
-import { SupplierDTO } from "../../generated";
 import { ISupplierState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: ISupplierState = {
-  supplierList: { status: "IDLE", data: new Array<SupplierDTO>() },
+  supplierList: new ApiResponse({
+    status: "IDLE",
+    data: [],
+  }),
 };

--- a/src/state/suppliers/types.ts
+++ b/src/state/suppliers/types.ts
@@ -1,6 +1,6 @@
 import { SupplierDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type ISupplierState = {
-  supplierList: IApiResponse<Array<SupplierDTO>>;
+  supplierList: ApiResponse<Array<SupplierDTO>>;
 };

--- a/src/state/therapies/initial.ts
+++ b/src/state/therapies/initial.ts
@@ -1,8 +1,9 @@
 import { ITherapiesState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: ITherapiesState = {
-  createTherapy: { status: "IDLE" },
-  updateTherapy: { status: "IDLE" },
-  therapiesByPatientId: { status: "IDLE", data: [] },
-  deleteTherapy: { status: "IDLE" },
+  createTherapy: new ApiResponse({ status: "IDLE" }),
+  updateTherapy: new ApiResponse({ status: "IDLE" }),
+  therapiesByPatientId: new ApiResponse({ status: "IDLE", data: [] }),
+  deleteTherapy: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/therapies/types.ts
+++ b/src/state/therapies/types.ts
@@ -1,9 +1,9 @@
 import { TherapyRowDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type ITherapiesState = {
-  createTherapy: IApiResponse<TherapyRowDTO>;
-  updateTherapy: IApiResponse<TherapyRowDTO>;
-  therapiesByPatientId: IApiResponse<Array<TherapyRowDTO>>;
-  deleteTherapy: IApiResponse<TherapyRowDTO>;
+  createTherapy: ApiResponse<TherapyRowDTO>;
+  updateTherapy: ApiResponse<TherapyRowDTO>;
+  therapiesByPatientId: ApiResponse<Array<TherapyRowDTO>>;
+  deleteTherapy: ApiResponse<TherapyRowDTO>;
 };

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,3 +1,5 @@
+import { immerable } from "immer";
+
 export interface IAction<Payload, Error> {
   type: string;
   payload?: Payload | Error;
@@ -13,6 +15,7 @@ export type TAPIResponseStatus =
   | "FAIL";
 
 export class ApiResponse<T> {
+  [immerable] = true;
   status?: TAPIResponseStatus;
   data?: T;
   error?: any;
@@ -30,7 +33,7 @@ export class ApiResponse<T> {
   }
 
   constructor(props: { status?: TAPIResponseStatus; data?: T; error?: any }) {
-    this.status = props.status;
+    this.status = props.status ?? "IDLE";
     this.data = props.data;
     this.error = props.error;
   }

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -12,10 +12,26 @@ export type TAPIResponseStatus =
   | "SUCCESS_EMPTY"
   | "FAIL";
 
-export interface IApiResponse<T> {
+export class ApiResponse<T> {
   status?: TAPIResponseStatus;
-  isLoading?: boolean;
-  hasSucceeded?: boolean;
   data?: T;
   error?: any;
+  get isLoading(): boolean {
+    return this.status === "LOADING";
+  }
+  get hasSucceeded(): boolean {
+    return this.status === "SUCCESS";
+  }
+  get hasFailed() {
+    return this.status === "FAIL";
+  }
+  get isSuccessEmpty() {
+    return this.status === "SUCCESS_EMPTY";
+  }
+
+  constructor(props: { status?: TAPIResponseStatus; data?: T; error?: any }) {
+    this.status = props.status;
+    this.data = props.data;
+    this.error = props.error;
+  }
 }

--- a/src/state/users/initial.ts
+++ b/src/state/users/initial.ts
@@ -1,6 +1,7 @@
 import { UserDTO } from "../../generated";
 import { IUserState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IUserState = {
-  userList: { status: "IDLE", data: new Array<UserDTO>() },
+  userList: new ApiResponse({ status: "IDLE", data: new Array<UserDTO>() }),
 };

--- a/src/state/users/types.ts
+++ b/src/state/users/types.ts
@@ -1,6 +1,6 @@
 import { UserDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IUserState = {
-  userList: IApiResponse<Array<UserDTO>>;
+  userList: ApiResponse<Array<UserDTO>>;
 };

--- a/src/state/visits/initial.ts
+++ b/src/state/visits/initial.ts
@@ -1,7 +1,8 @@
 import { IVisitState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IVisitState = {
-  getVisits: { status: "IDLE", data: [] },
-  createVisit: { status: "IDLE" },
-  updateVisit: { status: "IDLE" },
+  getVisits: new ApiResponse({ status: "IDLE", data: [] }),
+  createVisit: new ApiResponse({ status: "IDLE" }),
+  updateVisit: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/visits/types.ts
+++ b/src/state/visits/types.ts
@@ -1,8 +1,8 @@
 import { VisitDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IVisitState = {
-  getVisits: IApiResponse<Array<VisitDTO>>;
-  createVisit: IApiResponse<VisitDTO>;
-  updateVisit: IApiResponse<VisitDTO>;
+  getVisits: ApiResponse<Array<VisitDTO>>;
+  createVisit: ApiResponse<VisitDTO>;
+  updateVisit: ApiResponse<VisitDTO>;
 };

--- a/src/state/ward/initial.ts
+++ b/src/state/ward/initial.ts
@@ -1,8 +1,9 @@
 import { IWardState } from "./types";
+import { ApiResponse } from "../types";
 
 export const initial: IWardState = {
-  allWards: { status: "IDLE", data: [] },
-  create: { status: "IDLE" },
-  update: { status: "IDLE" },
-  delete: { status: "IDLE" },
+  allWards: new ApiResponse({ status: "IDLE", data: [] }),
+  create: new ApiResponse({ status: "IDLE" }),
+  update: new ApiResponse({ status: "IDLE" }),
+  delete: new ApiResponse({ status: "IDLE" }),
 };

--- a/src/state/ward/reducer.ts
+++ b/src/state/ward/reducer.ts
@@ -42,16 +42,12 @@ export default produce((draft: IWardState, action: IAction<any, any>) => {
 
     case CREATE_WARD_LOADING: {
       draft.create.status = "LOADING";
-      draft.create.hasSucceeded = false;
-      draft.create.isLoading = true;
       break;
     }
 
     case CREATE_WARD_SUCCESS: {
       draft.create.status = "SUCCESS";
       draft.create.data = action.payload;
-      draft.create.hasSucceeded = true;
-      draft.create.isLoading = false;
       delete draft.create.error;
       break;
     }
@@ -59,8 +55,6 @@ export default produce((draft: IWardState, action: IAction<any, any>) => {
     case CREATE_WARD_FAIL: {
       draft.create.status = "FAIL";
       draft.create.error = action.error;
-      draft.create.hasSucceeded = false;
-      draft.create.isLoading = false;
       break;
     }
 
@@ -68,23 +62,17 @@ export default produce((draft: IWardState, action: IAction<any, any>) => {
       draft.create.status = "IDLE";
       delete draft.create.error;
       delete draft.create.data;
-      draft.create.hasSucceeded = false;
-      draft.create.isLoading = false;
       break;
     }
 
     case UPDATE_WARD_LOADING: {
       draft.update.status = "LOADING";
-      draft.update.hasSucceeded = false;
-      draft.update.isLoading = true;
       break;
     }
 
     case UPDATE_WARD_SUCCESS: {
       draft.update.status = "SUCCESS";
       draft.update.data = action.payload;
-      draft.update.hasSucceeded = true;
-      draft.update.isLoading = false;
       delete draft.update.error;
       break;
     }
@@ -92,8 +80,6 @@ export default produce((draft: IWardState, action: IAction<any, any>) => {
     case UPDATE_WARD_FAIL: {
       draft.update.status = "FAIL";
       draft.update.error = action.error;
-      draft.update.hasSucceeded = false;
-      draft.update.isLoading = false;
       break;
     }
 
@@ -101,23 +87,17 @@ export default produce((draft: IWardState, action: IAction<any, any>) => {
       draft.update.status = "IDLE";
       delete draft.update.error;
       delete draft.update.data;
-      draft.update.hasSucceeded = false;
-      draft.update.isLoading = false;
       break;
     }
 
     case DELETE_WARD_LOADING: {
       draft.delete.status = "LOADING";
-      draft.delete.hasSucceeded = false;
-      draft.delete.isLoading = true;
       break;
     }
 
     case DELETE_WARD_SUCCESS: {
       draft.delete.status = "SUCCESS";
       draft.delete.data = action.payload;
-      draft.delete.hasSucceeded = true;
-      draft.delete.isLoading = false;
       delete draft.delete.error;
       break;
     }
@@ -125,8 +105,6 @@ export default produce((draft: IWardState, action: IAction<any, any>) => {
     case DELETE_WARD_FAIL: {
       draft.delete.status = "FAIL";
       draft.delete.error = action.error;
-      draft.delete.hasSucceeded = false;
-      draft.delete.isLoading = false;
       break;
     }
 
@@ -134,8 +112,6 @@ export default produce((draft: IWardState, action: IAction<any, any>) => {
       draft.delete.status = "IDLE";
       delete draft.delete.error;
       delete draft.delete.data;
-      draft.delete.hasSucceeded = false;
-      draft.delete.isLoading = false;
       break;
     }
   }

--- a/src/state/ward/types.ts
+++ b/src/state/ward/types.ts
@@ -1,9 +1,9 @@
 import { WardDTO } from "../../generated";
-import { IApiResponse } from "../types";
+import { ApiResponse } from "../types";
 
 export type IWardState = {
-  allWards: IApiResponse<Array<WardDTO>>;
-  create: IApiResponse<WardDTO>;
-  update: IApiResponse<WardDTO>;
-  delete: IApiResponse<boolean>;
+  allWards: ApiResponse<Array<WardDTO>>;
+  create: ApiResponse<WardDTO>;
+  update: ApiResponse<WardDTO>;
+  delete: ApiResponse<boolean>;
 };


### PR DESCRIPTION
This replace the IApiResponse interface with the ApiResponse class. Previously hasSucceeded and isLoading were read/write properties in defined types.
With this refactoring, isLoading and hasSucceeded are just getters and their returned value relies on the status proprerty.

There are two additional getters: hasFailed, isSuccessEmpty that rely also on the status property.

See [OH2-307](https://openhospital.atlassian.net/browse/OH2-307)

[OH2-307]: https://openhospital.atlassian.net/browse/OH2-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ