### PR TITLE
fix: remove admin prefix from formatted urls

### DIFF
--- a/src/libraries/formatUtils/urlFormatting.test.ts
+++ b/src/libraries/formatUtils/urlFormatting.test.ts
@@ -1,0 +1,13 @@
+import { extractUrlAfterAdmin } from "./urlFormatting";
+
+describe("extractUrlAfterAdmin", () => {
+  it("should return what's after /admin/", () => {
+    expect(extractUrlAfterAdmin("/admin/yaddah")).toEqual("yaddah");
+  });
+  it("should throw if not starting by /admin/", () => {
+    expect(() => extractUrlAfterAdmin("admin/yaddah")).toThrow();
+    expect(() => extractUrlAfterAdmin("/adminyaddah")).toThrow();
+    expect(() => extractUrlAfterAdmin("anything/admin/yaddah")).toThrow();
+    expect(() => extractUrlAfterAdmin("anything else")).toThrow();
+  });
+});

--- a/src/libraries/formatUtils/urlFormatting.ts
+++ b/src/libraries/formatUtils/urlFormatting.ts
@@ -1,0 +1,6 @@
+export const extractUrlAfterAdmin = (url: string) => {
+  if (!/^\/admin\//.test(url)) {
+    throw new Error("'/admin/' not found in the URL");
+  }
+  return url.substring(7); // 7 to skip over '/admin/'
+};

--- a/src/routes/Admin/AdminRoutes.tsx
+++ b/src/routes/Admin/AdminRoutes.tsx
@@ -22,19 +22,20 @@ import {
 import { PATHS } from "../../consts";
 import { NewSupplier } from "../../components/accessories/admin/suppliers/newSupplier";
 import { EditSupplier } from "../../components/accessories/admin/suppliers/editSupplier";
+import { extractUrlAfterAdmin } from "../../libraries/formatUtils/urlFormatting";
 
 export const AdminRoutes = () => {
   const { t } = useTranslation();
   const routes: { element: ReactNode; path: string }[] = useMemo(
     () => [
       {
-        path: PATHS.admin_wards,
+        path: extractUrlAfterAdmin(PATHS.admin_wards),
         element: (
           <AdminActivityContent title={t("nav.wards")} children={<Wards />} />
         ),
       },
       {
-        path: PATHS.admin_wards_new,
+        path: extractUrlAfterAdmin(PATHS.admin_wards_new),
         element: (
           <AdminActivityContent
             title={t("ward.addWard")}
@@ -43,7 +44,7 @@ export const AdminRoutes = () => {
         ),
       },
       {
-        path: PATHS.admin_wards_edit,
+        path: extractUrlAfterAdmin(PATHS.admin_wards_edit),
         element: (
           <AdminActivityContent
             title={t("ward.editWard")}
@@ -52,7 +53,7 @@ export const AdminRoutes = () => {
         ),
       },
       {
-        path: PATHS.admin_diseases,
+        path: extractUrlAfterAdmin(PATHS.admin_diseases),
         element: (
           <AdminActivityContent
             title={t("nav.diseases")}
@@ -61,7 +62,7 @@ export const AdminRoutes = () => {
         ),
       },
       {
-        path: PATHS.admin_diseases_new,
+        path: extractUrlAfterAdmin(PATHS.admin_diseases_new),
         element: (
           <AdminActivityContent
             title={t("disease.addDisease")}
@@ -70,7 +71,7 @@ export const AdminRoutes = () => {
         ),
       },
       {
-        path: PATHS.admin_diseases_edit,
+        path: extractUrlAfterAdmin(PATHS.admin_diseases_edit),
         element: (
           <AdminActivityContent
             title={t("disease.editDisease")}
@@ -85,7 +86,7 @@ export const AdminRoutes = () => {
         ),
       },
       {
-        path: PATHS.admin_operations,
+        path: extractUrlAfterAdmin(PATHS.admin_operations),
         element: (
           <AdminActivityContent
             title={t("nav.operations")}


### PR DESCRIPTION
Fixing an issue introduced in https://github.com/informatici/openhospital-ui/pull/596
as AdminRouter only applies in /admin/ let's remove this prefix when catching them.

this allows to catch `/admin/wards`, instead of current (wrongly) catching `/admin/admin/wards`

![Screen Recording 2024-06-06 at 17 16 29](https://github.com/informatici/openhospital-ui/assets/597067/2b29aee8-397d-4734-905e-24cb56d9e832)
