### PR TITLE
OH2-325 | Fix possibly bad designs

### DIFF
--- a/cypress/integrations/admin_activities/diseases_activities/manage_diseases_activity.cy.ts
+++ b/cypress/integrations/admin_activities/diseases_activities/manage_diseases_activity.cy.ts
@@ -13,7 +13,7 @@ describe("Diseases Activity specs", () => {
       .find("table")
       .then(($table) => {
         const rows = $table.find("tbody tr");
-        expect(rows.length).equal(3);
+        expect(rows.length).equal(6);
       });
   });
 });

--- a/src/components/accessories/admin/diseases/diseaseTable/DiseaseTable.tsx
+++ b/src/components/accessories/admin/diseases/diseaseTable/DiseaseTable.tsx
@@ -8,7 +8,7 @@ import { IState } from "../../../../../types";
 import { DiseaseDTO } from "../../../../../generated";
 import { ApiResponse } from "../../../../../state/types";
 import classes from "./DiseaseTable.module.scss";
-import { CheckOutlined } from "@material-ui/icons";
+import { CheckOutlined, CloseOutlined } from "@material-ui/icons";
 import { TFilterField } from "../../../table/filter/types";
 
 interface IOwnProps {
@@ -33,14 +33,7 @@ export const DiseaseTable: FunctionComponent<IOwnProps> = ({
       })) ?? []
   );
 
-  const header = [
-    "code",
-    "diseaseType",
-    "description",
-    "opdInclude",
-    "ipdInInclude",
-    "ipdOutInclude",
-  ];
+  const header = ["code", "diseaseType", "description"];
 
   const label = {
     code: t("disease.code"),
@@ -84,16 +77,20 @@ export const DiseaseTable: FunctionComponent<IOwnProps> = ({
         code: item.code ?? "",
         diseaseType: item.diseaseType?.description ?? "",
         description: item.description ?? "",
-        opdInclude: item.opdInclude ? <CheckOutlined fontSize="small" /> : "",
+        opdInclude: item.opdInclude ? (
+          <CheckOutlined fontSize="small" />
+        ) : (
+          <CloseOutlined color="primary" fontSize="small" />
+        ),
         ipdInInclude: item.ipdInInclude ? (
           <CheckOutlined fontSize="small" />
         ) : (
-          ""
+          <CloseOutlined color="primary" fontSize="small" />
         ),
         ipdOutInclude: item.ipdOutInclude ? (
           <CheckOutlined fontSize="small" />
         ) : (
-          ""
+          <CloseOutlined color="primary" fontSize="small" />
         ),
         lock: item.lock,
       };
@@ -126,6 +123,7 @@ export const DiseaseTable: FunctionComponent<IOwnProps> = ({
                   showEmptyCell={false}
                   rowKey={"code"}
                   manualFilter={false}
+                  isCollapsabile
                   filterColumns={filters}
                   rawData={(data ?? []).map((disease) => ({
                     ...disease,

--- a/src/components/accessories/admin/operations/operationTable/OperationTable.tsx
+++ b/src/components/accessories/admin/operations/operationTable/OperationTable.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode, useRef } from "react";
+import React, { FunctionComponent, ReactNode, useEffect, useRef } from "react";
 import Table from "../../../table/Table";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../../../infoBox/InfoBox";
@@ -12,6 +12,7 @@ import { TFilterField } from "../../../table/filter/types";
 import { deleteOperationReset } from "../../../../../state/operations/actions";
 import ConfirmationDialog from "../../../confirmationDialog/ConfirmationDialog";
 import checkIcon from "../../../../../assets/check-icon.png";
+import { scrollToElement } from "../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -84,6 +85,12 @@ export const OperationTable: FunctionComponent<IOwnProps> = ({
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteOperation.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteOperation.status]);
+
   const formatDataToDisplay = (data: OperationDTO[]) => {
     return data.map((item) => {
       return {
@@ -115,6 +122,14 @@ export const OperationTable: FunctionComponent<IOwnProps> = ({
           case "SUCCESS":
             return (
               <>
+                {deleteOperation.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteOperation.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -136,14 +151,6 @@ export const OperationTable: FunctionComponent<IOwnProps> = ({
                   }
                   headerActions={headerActions}
                 />
-                {deleteOperation.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteOperation.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={deleteOperation.status === "SUCCESS"}
                   title={t("operation.deleted")}

--- a/src/components/accessories/admin/types/components/admissions/admissionTypesTable/AdmissionTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/admissions/admissionTypesTable/AdmissionTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteAdmissionTypeReset } from "../../../../../../../state/types/admissions/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const AdmissionTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteAdmissionType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteAdmissionType.status]);
+
   const formatDataToDisplay = (data: AdmissionTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const AdmissionTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteAdmissionType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteAdmissionType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const AdmissionTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteAdmissionType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteAdmissionType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteAdmissionType.hasSucceeded}
                   title={t("admissionTypes.deleted")}

--- a/src/components/accessories/admin/types/components/deliveries/deliveryTypesTable/DeliveryTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/deliveries/deliveryTypesTable/DeliveryTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteDeliveryTypeReset } from "../../../../../../../state/types/deliveries/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const DeliveryTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteDeliveryType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteDeliveryType.status]);
+
   const formatDataToDisplay = (data: DeliveryTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const DeliveryTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteDeliveryType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteDeliveryType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const DeliveryTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteDeliveryType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteDeliveryType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteDeliveryType.hasSucceeded}
                   title={t("deliveryTypes.deleted")}

--- a/src/components/accessories/admin/types/components/deliveryresulttypes/deliveryResultTypeTable/DeliveryResultTypeTable.tsx
+++ b/src/components/accessories/admin/types/components/deliveryresulttypes/deliveryResultTypeTable/DeliveryResultTypeTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteDeliveryResultTypeReset } from "../../../../../../../state/types/deliveryResultType/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const DeliveryResultTypeTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteDeliveryResultType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteDeliveryResultType.status]);
+
   const formatDataToDisplay = (data: DeliveryResultTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const DeliveryResultTypeTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteDeliveryResultType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteDeliveryResultType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const DeliveryResultTypeTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteDeliveryResultType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteDeliveryResultType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteDeliveryResultType.hasSucceeded}
                   title={t("deliveryResultType.deleted")}

--- a/src/components/accessories/admin/types/components/discharges/dischargeTypesTable/DischargeTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/discharges/dischargeTypesTable/DischargeTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteDischargeTypeReset } from "../../../../../../../state/types/discharges/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const DischargeTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteDischargeType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteDischargeType.status]);
+
   const formatDataToDisplay = (data: DischargeTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const DischargeTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteDischargeType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteDischargeType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const DischargeTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteDischargeType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteDischargeType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteDischargeType.hasSucceeded}
                   title={t("dischargeTypes.deleted")}

--- a/src/components/accessories/admin/types/components/diseases/diseaseTypesTable/DiseaseTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/diseases/diseaseTypesTable/DiseaseTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteDiseaseTypeReset } from "../../../../../../../state/types/diseases/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const DiseaseTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteDiseaseType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteDiseaseType.status]);
+
   const formatDataToDisplay = (data: DiseaseTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const DiseaseTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteDiseaseType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteDiseaseType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const DiseaseTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteDiseaseType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteDiseaseType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteDiseaseType.hasSucceeded}
                   title={t("diseaseTypes.deleted")}

--- a/src/components/accessories/admin/types/components/exams/examTypesTable/ExamTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/exams/examTypesTable/ExamTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteExamTypeReset } from "../../../../../../../state/types/exams/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const ExamTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteExamType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteExamType.status]);
+
   const formatDataToDisplay = (data: ExamTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const ExamTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteExamType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteExamType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const ExamTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteExamType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteExamType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteExamType.hasSucceeded}
                   title={t("examTypes.deleted")}

--- a/src/components/accessories/admin/types/components/medicals/medicalTypesTable/MedicalTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/medicals/medicalTypesTable/MedicalTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteMedicalTypeReset } from "../../../../../../../state/types/medicals/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const MedicalTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteMedicalType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteMedicalType.status]);
+
   const formatDataToDisplay = (data: MedicalTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const MedicalTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteMedicalType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteMedicalType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const MedicalTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteMedicalType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteMedicalType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteMedicalType.hasSucceeded}
                   title={t("medicalTypes.deleted")}

--- a/src/components/accessories/admin/types/components/operations/operationTypesTable/OperationTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/operations/operationTypesTable/OperationTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteOperationTypeReset } from "../../../../../../../state/types/operations/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const OperationTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteOperationType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteOperationType.status]);
+
   const formatDataToDisplay = (data: OperationTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const OperationTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteOperationType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteOperationType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const OperationTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteOperationType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteOperationType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteOperationType.hasSucceeded}
                   title={t("operationTypes.deleted")}

--- a/src/components/accessories/admin/types/components/pregnanttreatmenttypes/pregnantTreatmentTableType/PregnantTreatmentTableType.tsx
+++ b/src/components/accessories/admin/types/components/pregnanttreatmenttypes/pregnantTreatmentTableType/PregnantTreatmentTableType.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deletePregnantTreatmentTypeReset } from "../../../../../../../state/types/pregnantTreatment/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const PregnantTreatmentTableType = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteDiseaseType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteDiseaseType.status]);
+
   const formatDataToDisplay = (data: PregnantTreatmentTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const PregnantTreatmentTableType = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteDiseaseType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteDiseaseType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const PregnantTreatmentTableType = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteDiseaseType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteDiseaseType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteDiseaseType.hasSucceeded}
                   title={t("pregnantTreatmentTypes.deleted")}

--- a/src/components/accessories/admin/types/components/vaccines/vaccineTypesTable/VaccineTypesTable.tsx
+++ b/src/components/accessories/admin/types/components/vaccines/vaccineTypesTable/VaccineTypesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { ApiResponse } from "../../../../../../../state/types";
@@ -11,6 +11,7 @@ import ConfirmationDialog from "../../../../../confirmationDialog/ConfirmationDi
 import { deleteVaccineTypeReset } from "../../../../../../../state/types/vaccines/actions";
 import checkIcon from "../../../../../../../assets/check-icon.png";
 import "./styles.scss";
+import { scrollToElement } from "../../../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -49,6 +50,12 @@ const VaccineTypesTable = (props: IOwnProps) => {
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteVaccineType.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteVaccineType.status]);
+
   const formatDataToDisplay = (data: VaccineTypeDTO[]) => {
     return data.map((item) => {
       return {
@@ -77,6 +84,14 @@ const VaccineTypesTable = (props: IOwnProps) => {
           case "SUCCESS":
             return (
               <>
+                {deleteVaccineType.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteVaccineType.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -92,14 +107,6 @@ const VaccineTypesTable = (props: IOwnProps) => {
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteVaccineType.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteVaccineType.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteVaccineType.hasSucceeded}
                   title={t("vaccineTypes.deleted")}

--- a/src/components/accessories/admin/vaccines/vaccinesTable/VaccinesTable.tsx
+++ b/src/components/accessories/admin/vaccines/vaccinesTable/VaccinesTable.tsx
@@ -16,6 +16,7 @@ import { TFilterField } from "../../../table/filter/types";
 import { getVaccineTypes } from "../../../../../state/types/vaccines/actions";
 import ConfirmationDialog from "../../../confirmationDialog/ConfirmationDialog";
 import checkIcon from "../../../../../assets/check-icon.png";
+import { scrollToElement } from "../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -84,6 +85,12 @@ export const VaccinesTable = ({
     onDelete(row);
   };
 
+  useEffect(() => {
+    if (deleteVaccine.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteVaccine.status]);
+
   const formatDataToDisplay = (data: VaccineDTO[]) => {
     return data.map((item) => {
       return {
@@ -112,6 +119,14 @@ export const VaccinesTable = ({
           case "SUCCESS":
             return (
               <>
+                {deleteVaccine.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox
+                      type="error"
+                      message={deleteVaccine.error?.message}
+                    />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -127,14 +142,6 @@ export const VaccinesTable = ({
                   onEdit={handleEdit}
                   onDelete={handleDelete}
                 />
-                {deleteVaccine.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox
-                      type="error"
-                      message={deleteVaccine.error?.message}
-                    />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteVaccine.hasSucceeded}
                   title={t("vaccine.deleted")}

--- a/src/components/accessories/admin/wards/wardTable/WardTable.module.scss
+++ b/src/components/accessories/admin/wards/wardTable/WardTable.module.scss
@@ -1,4 +1,4 @@
 .table {
   display: grid;
-  margin-top: 50px;
+  margin-top: 10px;
 }

--- a/src/components/accessories/admin/wards/wardTable/WardTable.tsx
+++ b/src/components/accessories/admin/wards/wardTable/WardTable.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode, useRef } from "react";
+import React, { FunctionComponent, ReactNode, useEffect, useRef } from "react";
 import Table from "../../../table/Table";
 import { useTranslation } from "react-i18next";
 import InfoBox from "../../../infoBox/InfoBox";
@@ -13,6 +13,7 @@ import ConfirmationDialog from "../../../confirmationDialog/ConfirmationDialog";
 import checkIcon from "../../../../../assets/check-icon.png";
 import { deleteWardReset } from "../../../../../state/ward/actions";
 import { TFilterField } from "../../../table/filter/types";
+import { scrollToElement } from "../../../../../libraries/uiUtils/scrollToElement";
 
 interface IOwnProps {
   onEdit: (row: any) => void;
@@ -70,6 +71,12 @@ export const WardTable: FunctionComponent<IOwnProps> = ({
   const handleDelete = (row: WardDTO) => {
     onDelete(row);
   };
+
+  useEffect(() => {
+    if (deleteWard.status === "FAIL") {
+      scrollToElement(infoBoxRef.current);
+    }
+  }, [deleteWard.status]);
 
   const formatDataToDisplay = (data: WardDTO[]) => {
     return data.map((item) => {

--- a/src/components/accessories/admin/wards/wardTable/WardTable.tsx
+++ b/src/components/accessories/admin/wards/wardTable/WardTable.tsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { IState } from "../../../../../types";
 import { WardDTO } from "../../../../../generated";
 import { ApiResponse } from "../../../../../state/types";
-import { CheckOutlined } from "@material-ui/icons";
+import { CheckOutlined, CloseOutlined } from "@material-ui/icons";
 import classes from "./WardTable.module.scss";
 import ConfirmationDialog from "../../../confirmationDialog/ConfirmationDialog";
 import checkIcon from "../../../../../assets/check-icon.png";
@@ -29,17 +29,7 @@ export const WardTable: FunctionComponent<IOwnProps> = ({
   const { t } = useTranslation();
   const infoBoxRef = useRef<HTMLDivElement>(null);
 
-  const header = [
-    "code",
-    "description",
-    "beds",
-    "nurs",
-    "docs",
-    "opd",
-    "pharmacy",
-    "male",
-    "female",
-  ];
+  const header = ["code", "description", "beds", "nurs", "docs"];
 
   const label = {
     code: t("ward.code"),
@@ -89,10 +79,26 @@ export const WardTable: FunctionComponent<IOwnProps> = ({
         beds: item.beds ?? "",
         nurs: item.nurs ?? "",
         docs: item.docs ?? "",
-        opd: item.opd ? <CheckOutlined fontSize="small" /> : "",
-        male: item.male ? <CheckOutlined fontSize="small" /> : "",
-        female: item.female ? <CheckOutlined fontSize="small" /> : "",
-        pharmacy: item.pharmacy ? <CheckOutlined fontSize="small" /> : "",
+        opd: item.opd ? (
+          <CheckOutlined fontSize="small" />
+        ) : (
+          <CloseOutlined color="primary" fontSize="small" />
+        ),
+        male: item.male ? (
+          <CheckOutlined fontSize="small" />
+        ) : (
+          <CloseOutlined color="primary" fontSize="small" />
+        ),
+        female: item.female ? (
+          <CheckOutlined fontSize="small" />
+        ) : (
+          <CloseOutlined color="primary" fontSize="small" />
+        ),
+        pharmacy: item.pharmacy ? (
+          <CheckOutlined fontSize="small" />
+        ) : (
+          <CloseOutlined color="primary" fontSize="small" />
+        ),
         email: item.email ?? "",
         telephone: item.telephone ?? "",
         fax: item.fax ?? "",
@@ -118,6 +124,11 @@ export const WardTable: FunctionComponent<IOwnProps> = ({
           case "SUCCESS":
             return (
               <>
+                {deleteWard.status === "FAIL" && (
+                  <div ref={infoBoxRef} className="info-box-container">
+                    <InfoBox type="error" message={deleteWard.error?.message} />
+                  </div>
+                )}
                 <Table
                   rowData={formatDataToDisplay(data ?? [])}
                   tableHeader={header}
@@ -134,11 +145,6 @@ export const WardTable: FunctionComponent<IOwnProps> = ({
                   rowKey="code"
                   headerActions={headerActions}
                 />
-                {deleteWard.status === "FAIL" && (
-                  <div ref={infoBoxRef} className="info-box-container">
-                    <InfoBox type="error" message={deleteWard.error?.message} />
-                  </div>
-                )}
                 <ConfirmationDialog
                   isOpen={!!deleteWard.hasSucceeded}
                   title={t("ward.deleted")}

--- a/src/components/accessories/infoBox/styles.scss
+++ b/src/components/accessories/infoBox/styles.scss
@@ -2,7 +2,7 @@
 
 .infoBox {
   padding: 10px 5px;
-  margin: 15px auto;
+  margin: 5px auto;
   position: relative;
   border-radius: 5px;
 

--- a/src/components/accessories/table/styles.scss
+++ b/src/components/accessories/table/styles.scss
@@ -55,6 +55,7 @@
     }
     .collapseItem_row {
       word-break: break-all;
+      display: flex;
     }
   }
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -21,4 +21,8 @@
       display: none !important;
     }
   }
+
+  .info-box-container {
+    margin: 15px 0px;
+  }
 }


### PR DESCRIPTION
See OH2-325

1. Before
We have to scroll to see action buttons
![ward1](https://github.com/informatici/openhospital-ui/assets/58907550/587f206d-adc3-4e32-88be-6199b03f2ecf)
![ward2](https://github.com/informatici/openhospital-ui/assets/58907550/078919bc-21a6-4eff-9757-77432de51821)

The error is displayed at the bottom of the page, causing an UX issue, as the user has to scroll to the bottom to see error message
![ward-error-bottom](https://github.com/informatici/openhospital-ui/assets/58907550/bb517256-64c7-4673-a973-3d0b4775a1a8)

2. After
I've reduced the number of columns displayed by default to make the table compact and so make the action buttons visible without the need to scroll.
![ward-min](https://github.com/informatici/openhospital-ui/assets/58907550/c36082c6-7277-451c-b784-387c754f3353)

I've also displayed the error message at the top of the page and an event to scroll to the message when it occurs
![ward-error-top](https://github.com/informatici/openhospital-ui/assets/58907550/be0878ca-e195-4318-b1a8-a8961acf9222)

I applied the fix in all admin functions