### PR TITLE
Clean up development console warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Open Hospital</title>
-    <script type="text/javascript" src="https://openhospital.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/r5gghz/b/3/bc54840da492f9ca037209037ef0522a/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=53f7755c"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/accessories/dashboard/dashboardContent/filter/DashboardFilter.tsx
+++ b/src/components/accessories/dashboard/dashboardContent/filter/DashboardFilter.tsx
@@ -51,8 +51,8 @@ export const DashboardFilter: FC<IOwnProps> = ({ onPeriodChange }) => {
 	);
 
 	const onIconClickHandler = useCallback(
-		(event?: { stopPropagation?: () => void }) => {
-			event?.stopPropagation?.();
+		(event: React.MouseEvent) => {
+			event.stopPropagation();
 			setOpen(!open);
 		},
 		[open],

--- a/src/components/accessories/dashboard/dashboardContent/filter/DashboardFilter.tsx
+++ b/src/components/accessories/dashboard/dashboardContent/filter/DashboardFilter.tsx
@@ -51,10 +51,24 @@ export const DashboardFilter: FC<IOwnProps> = ({ onPeriodChange }) => {
 	);
 
 	const onIconClickHandler = useCallback(
-		(_event: any) => {
+		(event?: { stopPropagation?: () => void }) => {
+			event?.stopPropagation?.();
 			setOpen(!open);
 		},
 		[open],
+	);
+
+	const CalendarTrigger = useCallback(
+		() => (
+			<IconButton
+				className="filter__calendarButton"
+				aria-label="Choose date"
+				onClick={onIconClickHandler}
+			>
+				<CalendarTodaySharp />
+			</IconButton>
+		),
+		[onIconClickHandler],
 	);
 
 	const handleDateRangeChange = useCallback(
@@ -137,7 +151,7 @@ export const DashboardFilter: FC<IOwnProps> = ({ onPeriodChange }) => {
 					exclusive
 					onChange={handleSelectionChange}
 				>
-					<ToggleButton value="custom">
+					<ToggleButton value="custom" component="div">
 						<div className="filter__datefield">
 							<span>{period ?? 'Custom'}</span>
 							{view === 'range' ? (
@@ -148,16 +162,6 @@ export const DashboardFilter: FC<IOwnProps> = ({ onPeriodChange }) => {
 									format="dd/MM/YYY"
 									onClose={() => setOpen(false)}
 									onChange={handleDateRangeChange}
-									TextFieldComponent={(_props) => (
-										<IconButton
-											onClick={() => {
-												setOpen(!open);
-											}}
-										>
-											<CalendarTodaySharp />
-										</IconButton>
-									)}
-									open={open}
 								/>
 							) : (
 								<DateField
@@ -168,11 +172,7 @@ export const DashboardFilter: FC<IOwnProps> = ({ onPeriodChange }) => {
 									fieldValue={dateRange[0]?.toISOString() ?? ''}
 									format="dd/MM/YYY"
 									onChange={handleDateChange}
-									TextFieldComponent={(_props) => (
-										<IconButton onClick={onIconClickHandler}>
-											<CalendarTodaySharp />
-										</IconButton>
-									)}
+									TextFieldComponent={CalendarTrigger}
 									open={open}
 								/>
 							)}

--- a/src/components/accessories/dashboard/dashboardContent/filter/styles.scss
+++ b/src/components/accessories/dashboard/dashboardContent/filter/styles.scss
@@ -46,11 +46,20 @@
       justify-content: end;
     }
   }
-  filter__datefield {
+  .filter__datefield {
     display: flex;
     gap: 4px;
+    align-items: center;
     @include susy-media($smartphone) {
       flex-direction: column;
     }
+  }
+  .filter__calendarButton {
+    align-items: center;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    justify-content: center;
+    padding-left: 10px;
   }
 }

--- a/src/components/accessories/dateField/DateField.tsx
+++ b/src/components/accessories/dateField/DateField.tsx
@@ -47,6 +47,7 @@ const DateField: FunctionComponent<IProps> = ({
 		<div ref={anchorElRef}>
 			{matches ? (
 				<DesktopDatePicker
+					enableAccessibleFieldDOMStructure={false}
 					format={format}
 					label={
 						required === FIELD_VALIDATION.SUGGESTED ? `${label} **` : label
@@ -79,6 +80,7 @@ const DateField: FunctionComponent<IProps> = ({
 				/>
 			) : (
 				<MobileDatePicker
+					enableAccessibleFieldDOMStructure={false}
 					format={format}
 					label={
 						required === FIELD_VALIDATION.SUGGESTED ? `${label} **` : label

--- a/src/components/accessories/textField/TextField.tsx
+++ b/src/components/accessories/textField/TextField.tsx
@@ -19,6 +19,7 @@ const TextField: FunctionComponent<IProps> = ({
 	rows = 10,
 	required = FIELD_VALIDATION.IDLE,
 	maxLength,
+	inputProps,
 }) => {
 	const { t } = useTranslation();
 
@@ -43,7 +44,7 @@ const TextField: FunctionComponent<IProps> = ({
 				margin="dense"
 				disabled={disabled}
 				InputProps={InputProps}
-				inputProps={{ maxLength }}
+				inputProps={{ ...inputProps, maxLength }}
 				InputLabelProps={{ shrink: !!field.value }}
 				required={required === FIELD_VALIDATION.REQUIRED}
 			/>

--- a/src/components/accessories/textField/types.ts
+++ b/src/components/accessories/textField/types.ts
@@ -24,4 +24,5 @@ export interface IProps {
 	rows?: number;
 	required?: FIELD_VALIDATION;
 	maxLength?: number;
+	inputProps?: Record<string, unknown>;
 }

--- a/src/components/activities/loginActivity/LoginActivity.tsx
+++ b/src/components/activities/loginActivity/LoginActivity.tsx
@@ -95,6 +95,9 @@ export const LoginActivity: FC = () => {
 									isValid={isValid('username')}
 									errorText={getErrorText('username')}
 									onBlur={formik.handleBlur}
+									inputProps={{
+										autoComplete: 'username',
+									}}
 								/>
 							</div>
 							<div className="login__panel__textField">
@@ -106,6 +109,9 @@ export const LoginActivity: FC = () => {
 									isValid={isValid('password')}
 									errorText={getErrorText('password')}
 									onBlur={formik.handleBlur}
+									inputProps={{
+										autoComplete: 'current-password',
+									}}
 									InputProps={{
 										endAdornment: (
 											<InputAdornment position="end">

--- a/src/libraries/dashboardUtils/admissions/useAdmByAdmTypeData.ts
+++ b/src/libraries/dashboardUtils/admissions/useAdmByAdmTypeData.ts
@@ -2,13 +2,15 @@ import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '~/libraries/hooks/redux';
 import { colorGen } from '../../uiUtils/colorGenerator';
 
+const EMPTY_DATA: never[] = [];
+
 export const useAdmByAdmTypeData = () => {
 	const { t } = useTranslation();
 	const admissions = useAppSelector(
-		(state) => state.admissions.getAdmissions.data?.data ?? [],
+		(state) => state.admissions.getAdmissions.data?.data ?? EMPTY_DATA,
 	);
 	const admissionTypes = useAppSelector(
-		(state) => state.types.admissions.getAll.data ?? [],
+		(state) => state.types.admissions.getAll.data ?? EMPTY_DATA,
 	);
 	const admissionTypeStatus = useAppSelector(
 		(state) => state.types.admissions.getAll.status ?? 'IDLE',

--- a/src/libraries/dashboardUtils/admissions/useAdmByAgeTypeData.ts
+++ b/src/libraries/dashboardUtils/admissions/useAdmByAgeTypeData.ts
@@ -1,13 +1,15 @@
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '~/libraries/hooks/redux';
 
+const EMPTY_DATA: never[] = [];
+
 export const useAdmByAgeTypeData = () => {
 	const { t } = useTranslation();
 	const admissions = useAppSelector(
-		(state) => state.admissions.getAdmissions.data?.data ?? [],
+		(state) => state.admissions.getAdmissions.data?.data ?? EMPTY_DATA,
 	);
 	const ageTypes = useAppSelector(
-		(state) => state.types.ageTypes.getAll.data ?? [],
+		(state) => state.types.ageTypes.getAll.data ?? EMPTY_DATA,
 	);
 	const ageTypeStatus = useAppSelector(
 		(state) => state.types.ageTypes.getAll.status ?? 'IDLE',

--- a/src/libraries/dashboardUtils/admissions/useAdmBySexData.ts
+++ b/src/libraries/dashboardUtils/admissions/useAdmBySexData.ts
@@ -1,10 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '~/libraries/hooks/redux';
 
+const EMPTY_DATA: never[] = [];
+
 export const useAdmBySexData = () => {
 	const { t } = useTranslation();
 	const admissions = useAppSelector(
-		(state) => state.admissions.getAdmissions.data?.data ?? [],
+		(state) => state.admissions.getAdmissions.data?.data ?? EMPTY_DATA,
 	);
 	const status = useAppSelector(
 		(state) => state.admissions.getAdmissions.status ?? 'IDLE',

--- a/src/libraries/dashboardUtils/admissions/useAdmByWardData.ts
+++ b/src/libraries/dashboardUtils/admissions/useAdmByWardData.ts
@@ -1,12 +1,16 @@
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '~/libraries/hooks/redux';
 
+const EMPTY_DATA: never[] = [];
+
 export const useAdmByAdmWardData = () => {
 	const { t } = useTranslation();
 	const admissions = useAppSelector(
-		(state) => state.admissions.getAdmissions.data?.data ?? [],
+		(state) => state.admissions.getAdmissions.data?.data ?? EMPTY_DATA,
 	);
-	const wards = useAppSelector((state) => state.wards.allWards.data ?? []);
+	const wards = useAppSelector(
+		(state) => state.wards.allWards.data ?? EMPTY_DATA,
+	);
 	const wardStatus = useAppSelector(
 		(state) => state.wards.allWards.status ?? 'IDLE',
 	);

--- a/src/libraries/dashboardUtils/opds/useOpdByAgeTypeData.ts
+++ b/src/libraries/dashboardUtils/opds/useOpdByAgeTypeData.ts
@@ -1,13 +1,15 @@
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '~/libraries/hooks/redux';
 
+const EMPTY_DATA: never[] = [];
+
 export const useOpdByAgeTypeData = () => {
 	const { t } = useTranslation();
 	const opds = useAppSelector(
-		(state) => state.opds.searchOpds.data?.data ?? [],
+		(state) => state.opds.searchOpds.data?.data ?? EMPTY_DATA,
 	);
 	const ageTypes = useAppSelector(
-		(state) => state.types.ageTypes.getAll.data ?? [],
+		(state) => state.types.ageTypes.getAll.data ?? EMPTY_DATA,
 	);
 	const ageTypeStatus = useAppSelector(
 		(state) => state.types.ageTypes.getAll.status ?? 'IDLE',

--- a/src/libraries/dashboardUtils/opds/useOpdBySexData.ts
+++ b/src/libraries/dashboardUtils/opds/useOpdBySexData.ts
@@ -1,10 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { useAppSelector } from '~/libraries/hooks/redux';
 
+const EMPTY_DATA: never[] = [];
+
 export const useOpdBySexData = () => {
 	const { t } = useTranslation();
 	const opds = useAppSelector(
-		(state) => state.opds.searchOpds.data?.data ?? [],
+		(state) => state.opds.searchOpds.data?.data ?? EMPTY_DATA,
 	);
 	const status = useAppSelector(
 		(state) => state.opds.searchOpds.status ?? 'IDLE',

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -5,6 +5,8 @@ import { Private } from '../components/Private';
 import { ADMIN_ROUTES } from './admin';
 import { PATIENT_ROUTES } from './patients';
 
+const RouteHydrateFallback = () => null;
+
 export const router = createBrowserRouter([
 	{
 		path: '',
@@ -12,6 +14,7 @@ export const router = createBrowserRouter([
 	},
 	{
 		path: 'login',
+		HydrateFallback: RouteHydrateFallback,
 		lazy: async () =>
 			import('../components/activities/loginActivity/LoginActivity').then(
 				(module) => ({
@@ -21,6 +24,7 @@ export const router = createBrowserRouter([
 	},
 	{
 		path: 'forgot',
+		HydrateFallback: RouteHydrateFallback,
 		lazy: async () =>
 			import('../components/activities/forgotActivity/ForgotActivity').then(
 				(module) => ({
@@ -31,6 +35,7 @@ export const router = createBrowserRouter([
 	{
 		path: '*',
 		element: <Private />,
+		HydrateFallback: RouteHydrateFallback,
 		children: [
 			{
 				path: 'dashboard',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(() => {
 			alias: {
 				'~': path.resolve(__dirname, './src'),
 			},
+			dedupe: ['@emotion/react', '@emotion/styled'],
 		},
 		build: {
 			outDir: 'build',


### PR DESCRIPTION
## Summary
- Add autocomplete attributes to login fields.
- Fix dashboard date filter markup and MUI X picker compatibility.
- Stabilize dashboard selector fallback arrays to avoid unnecessary rerender warnings.
- Dedupe Emotion packages in Vite resolution.
- Add a hydrate fallback for lazy routes.

## Verification
- npm run tsc
- npm run build
