### PR TITLE
OP-896 Force password change in the web UI when required

### DIFF
--- a/api/oh.yaml
+++ b/api/oh.yaml
@@ -8260,6 +8260,14 @@ components:
         mustChangePassword:
           type: boolean
           description: Whether the user must change the password before using the application
+        passwordExpired:
+          type: boolean
+          description: Whether the password change is required because the password lease has expired
+        passwordLeaseDays:
+          type: integer
+          format: int32
+          description: The configured password lease in days when the policy is active, null otherwise
+          example: 90
     LoginRequest:
       type: object
       properties:

--- a/api/oh.yaml
+++ b/api/oh.yaml
@@ -8257,6 +8257,9 @@ components:
           type: string
           description: User name
           example: admin
+        mustChangePassword:
+          type: boolean
+          description: Whether the user must change the password before using the application
     LoginRequest:
       type: object
       properties:

--- a/src/components/Private.tsx
+++ b/src/components/Private.tsx
@@ -1,10 +1,23 @@
-import { Navigate, Outlet } from 'react-router-dom';
-import { PATHS } from '../consts';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { AUTH_KEY, PATHS } from '../consts';
 import { isAuthenticated } from '../libraries/authUtils/isAuthenticated';
 import { useAuthentication } from '../libraries/authUtils/useAuthentication';
+import { SessionStorage } from '../libraries/storage/storage';
 
 export const Private = () => {
 	useAuthentication();
+	const location = useLocation();
 
-	return isAuthenticated() ? <Outlet /> : <Navigate to={PATHS.login} replace />;
+	if (!isAuthenticated()) {
+		return <Navigate to={PATHS.login} replace />;
+	}
+
+	// OP-896: until the password has been changed, confine the user to the change-password page
+	const mustChangePassword =
+		SessionStorage.read(AUTH_KEY)?.mustChangePassword === true;
+	if (mustChangePassword && location.pathname !== PATHS.change_password) {
+		return <Navigate to={PATHS.change_password} replace />;
+	}
+
+	return <Outlet />;
 };

--- a/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
+++ b/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
@@ -17,6 +17,12 @@ import TextField from '../../accessories/textField/TextField';
 import '../loginActivity/styles.scss';
 import type { IValues } from './types';
 
+// Mirrors the server-side password policy (GeneralData STRONGLENGTH default and
+// UserBrowsingManager.isPasswordStrong); the backend remains the source of truth.
+const MIN_PASSWORD_LENGTH = 6;
+const STRONG_PASSWORD_REGEX =
+	/^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[\\_$&+,:;=?@#|/'<>.^*()%!-])(?=\S+$).+$/;
+
 export const ChangePasswordActivity: FC = () => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -32,7 +38,10 @@ export const ChangePasswordActivity: FC = () => {
 	};
 
 	const validationSchema = object({
-		newPassword: string().required(t('login.insertthepassword')),
+		newPassword: string()
+			.required(t('login.insertthepassword'))
+			.min(MIN_PASSWORD_LENGTH, t('changepassword.passwordtooshort'))
+			.matches(STRONG_PASSWORD_REGEX, t('changepassword.passwordnotstrong')),
 		repeatPassword: string()
 			.required(t('login.insertthepassword'))
 			.oneOf([ref('newPassword')], t('changepassword.passwordsdonotmatch')),

--- a/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
+++ b/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
@@ -23,7 +23,6 @@ export const ChangePasswordActivity: FC = () => {
 	const navigate = useNavigate();
 	const landingPageRoute = useLandingPageRoute();
 
-	const [isPasswordVisible] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const [errorMessage, setErrorMessage] = useState('');
 
@@ -92,7 +91,7 @@ export const ChangePasswordActivity: FC = () => {
 								field={formik.getFieldProps('newPassword')}
 								theme="regular"
 								label={t('changepassword.newpassword')}
-								type={isPasswordVisible ? 'text' : 'password'}
+								type="password"
 								isValid={isValid('newPassword')}
 								errorText={getErrorText('newPassword')}
 								onBlur={formik.handleBlur}
@@ -106,7 +105,7 @@ export const ChangePasswordActivity: FC = () => {
 								field={formik.getFieldProps('repeatPassword')}
 								theme="regular"
 								label={t('changepassword.repeatpassword')}
-								type={isPasswordVisible ? 'text' : 'password'}
+								type="password"
 								isValid={isValid('repeatPassword')}
 								errorText={getErrorText('repeatPassword')}
 								onBlur={formik.handleBlur}

--- a/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
+++ b/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
@@ -80,6 +80,14 @@ export const ChangePasswordActivity: FC = () => {
 		return has(formik.touched, fieldName) ? get(formik.errors, fieldName) : '';
 	};
 
+	// explain why the change is forced: a lease expiry (with the configured days) or an administrator reset.
+	// read from the session so the reason survives a page refresh (redux rehydration drops the extra fields).
+	const auth = SessionStorage.read(AUTH_KEY);
+	const description =
+		auth?.passwordExpired && auth?.passwordLeaseDays != null
+			? t('changepassword.expired', { days: auth.passwordLeaseDays })
+			: t('changepassword.adminreset');
+
 	return (
 		<div className="login">
 			<div className="container login__background">
@@ -91,9 +99,7 @@ export const ChangePasswordActivity: FC = () => {
 				/>
 				<div className="login__title">{t('changepassword.title')}</div>
 				<div data-cy="change-password-panel" className="login__panel">
-					<div className="login__panel__description">
-						{t('changepassword.description')}
-					</div>
+					<div className="login__panel__description">{description}</div>
 					<form className="login__panel__form" onSubmit={formik.handleSubmit}>
 						<div className="login__panel__textField">
 							<TextField

--- a/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
+++ b/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
@@ -1,0 +1,144 @@
+import classNames from 'classnames';
+import { useFormik } from 'formik';
+import { get, has } from 'lodash';
+import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { object, ref, string } from 'yup';
+import { useAppDispatch } from '~/libraries/hooks/redux';
+import logo from '../../../assets/logo-color.svg';
+import { AUTH_KEY } from '../../../consts';
+import { useLandingPageRoute } from '../../../libraries/hooks/useLandingPageRoute';
+import { SessionStorage } from '../../../libraries/storage/storage';
+import { changePassword, clearMustChangePassword } from '../../../state/main';
+import Button from '../../accessories/button/Button';
+import Footer from '../../accessories/footer/Footer';
+import TextField from '../../accessories/textField/TextField';
+import '../loginActivity/styles.scss';
+import type { IValues } from './types';
+
+export const ChangePasswordActivity: FC = () => {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+	const navigate = useNavigate();
+	const landingPageRoute = useLandingPageRoute();
+
+	const [isPasswordVisible] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [errorMessage, setErrorMessage] = useState('');
+
+	const initialValues: IValues = {
+		newPassword: '',
+		repeatPassword: '',
+	};
+
+	const validationSchema = object({
+		newPassword: string().required(t('login.insertthepassword')),
+		repeatPassword: string()
+			.required(t('login.insertthepassword'))
+			.oneOf([ref('newPassword')], t('changepassword.passwordsdonotmatch')),
+	});
+
+	const formik = useFormik({
+		initialValues,
+		validationSchema,
+		onSubmit: async (values: IValues) => {
+			setIsLoading(true);
+			setErrorMessage('');
+			try {
+				await dispatch(
+					changePassword({ password: values.newPassword }),
+				).unwrap();
+				// keep the session/redux flag in sync so the guard lets the user through
+				const auth = SessionStorage.read(AUTH_KEY);
+				SessionStorage.write(AUTH_KEY, { ...auth, mustChangePassword: false });
+				dispatch(clearMustChangePassword());
+				navigate(landingPageRoute, { replace: true });
+			} catch (error) {
+				// the rejected value is the raw API error response
+				const message = (error as { message?: string })?.message;
+				setErrorMessage(t(message ?? 'errors.somethingwrong'));
+			} finally {
+				setIsLoading(false);
+			}
+		},
+	});
+
+	const isValid = (fieldName: string): boolean => {
+		return has(formik.touched, fieldName) && has(formik.errors, fieldName);
+	};
+
+	const getErrorText = (fieldName: string): string => {
+		return has(formik.touched, fieldName) ? get(formik.errors, fieldName) : '';
+	};
+
+	return (
+		<div className="login">
+			<div className="container login__background">
+				<img
+					src={logo}
+					alt="Open Hospital"
+					className="login__logo"
+					width="150px"
+				/>
+				<div className="login__title">{t('changepassword.title')}</div>
+				<div data-cy="change-password-panel" className="login__panel">
+					<div className="login__panel__description">
+						{t('changepassword.description')}
+					</div>
+					<form className="login__panel__form" onSubmit={formik.handleSubmit}>
+						<div className="login__panel__textField">
+							<TextField
+								field={formik.getFieldProps('newPassword')}
+								theme="regular"
+								label={t('changepassword.newpassword')}
+								type={isPasswordVisible ? 'text' : 'password'}
+								isValid={isValid('newPassword')}
+								errorText={getErrorText('newPassword')}
+								onBlur={formik.handleBlur}
+								inputProps={{
+									autoComplete: 'new-password',
+								}}
+							/>
+						</div>
+						<div className="login__panel__textField">
+							<TextField
+								field={formik.getFieldProps('repeatPassword')}
+								theme="regular"
+								label={t('changepassword.repeatpassword')}
+								type={isPasswordVisible ? 'text' : 'password'}
+								isValid={isValid('repeatPassword')}
+								errorText={getErrorText('repeatPassword')}
+								onBlur={formik.handleBlur}
+								inputProps={{
+									autoComplete: 'new-password',
+								}}
+							/>
+						</div>
+						<div
+							data-cy="change-password-error"
+							className={classNames('login__invalidCredentials', {
+								hidden: !errorMessage,
+							})}
+						>
+							{errorMessage}
+						</div>
+						<div className="login__buttonContainer">
+							<Button
+								type="submit"
+								variant="contained"
+								color="primary"
+								disabled={isLoading}
+							>
+								{t('changepassword.submit')}
+							</Button>
+						</div>
+					</form>
+				</div>
+			</div>
+			<Footer />
+		</div>
+	);
+};
+
+export default ChangePasswordActivity;

--- a/src/components/activities/changePasswordActivity/types.ts
+++ b/src/components/activities/changePasswordActivity/types.ts
@@ -1,0 +1,4 @@
+export interface IValues {
+	newPassword: string;
+	repeatPassword: string;
+}

--- a/src/components/activities/loginActivity/RedirectAfterLogin.tsx
+++ b/src/components/activities/loginActivity/RedirectAfterLogin.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useMemo } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import { useAppSelector } from '~/libraries/hooks/redux';
+import { PATHS } from '../../../consts';
 import { useLandingPageRoute } from '../../../libraries/hooks/useLandingPageRoute';
 import type { IMainState } from '../../../state/main';
 import type { IRedirectAfterLogin } from './types';
@@ -27,6 +28,10 @@ export const RedirectAfterLogin: React.FC<IRedirectAfterLogin> = ({
 	);
 
 	if (status === 'SUCCESS') {
+		// OP-896: force the password change before reaching the landing page
+		if (state.authentication.data?.mustChangePassword) {
+			return <Navigate to={PATHS.change_password} replace />;
+		}
 		return <Navigate to={to} />;
 	}
 

--- a/src/components/activities/loginActivity/styles.scss
+++ b/src/components/activities/loginActivity/styles.scss
@@ -38,11 +38,20 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 0px;
+    padding: 0px 0px 20px 0px;
     background-color: $c-white;
     border-radius: 10px;
     width: fit-content;
     box-shadow: 0 4px 8px 0 rgba(48, 49, 51, 0.1);
+
+    .login__panel__description {
+      max-width: 320px;
+      margin: 20px 20px 0px 20px;
+      text-align: center;
+      color: $c-black;
+      font-size: 14px;
+      line-height: 1.4;
+    }
 
     .login__panel__form {
       display: flex;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,6 +8,7 @@ export const REFRESH_TOKEN_EXPIRATION_TIMEOUT = 0;
 export const PATHS = {
 	home: '/',
 	login: '/login',
+	change_password: '/change-password',
 	patients: '/patients',
 	patients_new: '/patients/new',
 	patients_search: '/patients/search',

--- a/src/libraries/authUtils/getAuthenticationFromSession.ts
+++ b/src/libraries/authUtils/getAuthenticationFromSession.ts
@@ -4,7 +4,8 @@ import { SessionStorage } from '../storage/storage';
 
 export const getAuthenticationFromSession = (): IAuthentication => {
 	const { permissions } = SessionStorage.read(PERMISSION_KEY);
-	const { username, token, mustChangePassword } = SessionStorage.read(AUTH_KEY);
+	const { username, token, mustChangePassword, passwordExpired, passwordLeaseDays } =
+		SessionStorage.read(AUTH_KEY);
 
 	if (!(token && username && permissions)) {
 		throw new Error('unauthenticated');
@@ -15,5 +16,7 @@ export const getAuthenticationFromSession = (): IAuthentication => {
 		permissions,
 		token,
 		mustChangePassword,
+		passwordExpired,
+		passwordLeaseDays,
 	};
 };

--- a/src/libraries/authUtils/getAuthenticationFromSession.ts
+++ b/src/libraries/authUtils/getAuthenticationFromSession.ts
@@ -4,7 +4,7 @@ import { SessionStorage } from '../storage/storage';
 
 export const getAuthenticationFromSession = (): IAuthentication => {
 	const { permissions } = SessionStorage.read(PERMISSION_KEY);
-	const { username, token } = SessionStorage.read(AUTH_KEY);
+	const { username, token, mustChangePassword } = SessionStorage.read(AUTH_KEY);
 
 	if (!(token && username && permissions)) {
 		throw new Error('unauthenticated');
@@ -14,5 +14,6 @@ export const getAuthenticationFromSession = (): IAuthentication => {
 		username,
 		permissions,
 		token,
+		mustChangePassword,
 	};
 };

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -11,6 +11,7 @@ export const auth = [
 					username: 'John Doe',
 					token:
 						'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsImF1dGgiOiJhZG1pbiIsImV4cCI6MTczOTE5MzU1MTAwMH0.D50o5x2gcVcASSwl7EOqmRUDGqIGfhisbXlkujQolrY',
+					mustChangePassword: false,
 				});
 	}),
 	http.post('/auth/logout', ({ response }) => {

--- a/src/mocks/routes/auth.ts
+++ b/src/mocks/routes/auth.ts
@@ -1,5 +1,8 @@
 import type { PollyServer } from '@pollyjs/core';
 
+const TOKEN =
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsImF1dGgiOiJhZG1pbiIsImV4cCI6MTczOTE5MzU1MTAwMH0.D50o5x2gcVcASSwl7EOqmRUDGqIGfhisbXlkujQolrY';
+
 export const authRoutes = (server: PollyServer) => {
 	server.namespace('/auth', () => {
 		server.post('/login').intercept((req, res) => {
@@ -9,11 +12,29 @@ export const authRoutes = (server: PollyServer) => {
 				case 'fail':
 					res.status(401);
 					break;
+				// log in as "expired" or "reset" to exercise the forced password change (OP-896)
+				case 'expired':
+					res.status(200).json({
+						username: 'John Doe',
+						token: TOKEN,
+						mustChangePassword: true,
+						passwordExpired: true,
+						passwordLeaseDays: 90,
+					});
+					break;
+				case 'reset':
+					res.status(200).json({
+						username: 'John Doe',
+						token: TOKEN,
+						mustChangePassword: true,
+						passwordExpired: false,
+					});
+					break;
 				default:
 					res.status(200).json({
 						username: 'John Doe',
-						token:
-							'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZG1pbiIsImF1dGgiOiJhZG1pbiIsImV4cCI6MTczOTE5MzU1MTAwMH0.D50o5x2gcVcASSwl7EOqmRUDGqIGfhisbXlkujQolrY',
+						token: TOKEN,
+						mustChangePassword: false,
 					});
 					break;
 			}

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -98,7 +98,9 @@
 		"repeatpassword": "Repeat new password",
 		"submit": "Change password",
 		"success": "Your password has been changed.",
-		"passwordsdonotmatch": "The passwords do not match"
+		"passwordsdonotmatch": "The passwords do not match",
+		"passwordtooshort": "Password too short",
+		"passwordnotstrong": "Use letter, number, symbol"
 	},
 	"dashboard": {
 		"welcomename": "Welcome",

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -94,6 +94,8 @@
 	"changepassword": {
 		"title": "Change your password",
 		"description": "You must change your password before you can continue.",
+		"expired": "Your password has expired after {{days}} days. Please choose a new password to continue.",
+		"adminreset": "Your password was assigned or reset by an administrator. Please choose a new password to continue.",
 		"newpassword": "New password",
 		"repeatpassword": "Repeat new password",
 		"submit": "Change password",

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -91,6 +91,15 @@
 		"takemeback": "Take me back to login",
 		"tryanotherusername": "Try another Username"
 	},
+	"changepassword": {
+		"title": "Change your password",
+		"description": "You must change your password before you can continue.",
+		"newpassword": "New password",
+		"repeatpassword": "Repeat new password",
+		"submit": "Change password",
+		"success": "Your password has been changed.",
+		"passwordsdonotmatch": "The passwords do not match"
+	},
 	"dashboard": {
 		"welcomename": "Welcome",
 		"newpatient": "New patient",

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -38,6 +38,15 @@ export const router = createBrowserRouter([
 		HydrateFallback: RouteHydrateFallback,
 		children: [
 			{
+				path: 'change-password',
+				lazy: async () =>
+					import(
+						'../components/activities/changePasswordActivity/ChangePasswordActivity'
+					).then((module) => ({
+						Component: module.ChangePasswordActivity,
+					})),
+			},
+			{
 				path: 'dashboard',
 				lazy: async () =>
 					import('../components/accessories/dashboard/Dashboard').then(

--- a/src/state/main/slice.ts
+++ b/src/state/main/slice.ts
@@ -18,6 +18,11 @@ export const mainSlice = createSlice({
 		) => {
 			state.authentication = ApiResponse.value(payload);
 		},
+		clearMustChangePassword: (state) => {
+			if (state.authentication.data) {
+				state.authentication.data.mustChangePassword = false;
+			}
+		},
 		setLogoutReset: (state) => {
 			state.logout = initial.logout;
 		},
@@ -85,6 +90,7 @@ export const mainSlice = createSlice({
 export const {
 	resetForgotPassword,
 	setAuthenticationSuccess,
+	clearMustChangePassword,
 	setLogoutLoading,
 	setLogoutSuccess,
 	setLogoutFailed,

--- a/src/state/main/thunk.ts
+++ b/src/state/main/thunk.ts
@@ -1,7 +1,12 @@
 import { createAsyncThunk, type Dispatch } from '@reduxjs/toolkit';
 import { concat, firstValueFrom } from 'rxjs';
-import { tap, toArray } from 'rxjs/operators';
-import { LoginApi, UserSettingsApi, UsersApi } from '../../generated';
+import { switchMap, tap, toArray } from 'rxjs/operators';
+import {
+	LoginApi,
+	type UserGroupDTO,
+	UserSettingsApi,
+	UsersApi,
+} from '../../generated';
 import { customConfiguration } from '../../libraries/apiUtils/configuration';
 import { saveAuthenticationDataToSession } from '../../libraries/authUtils/saveAuthenticationDataToSession';
 import { savePermissionDataToSession } from '../../libraries/authUtils/savePermissionDataToSession';
@@ -61,6 +66,24 @@ export const setLogout =
 			},
 		);
 	};
+
+export const changePassword = createAsyncThunk(
+	'main/changePassword',
+	async (payload: { password: string }, thunkApi) =>
+		firstValueFrom(
+			usersApi.retrieveProfileByCurrentLoggedInUser().pipe(
+				switchMap((profile) =>
+					usersApi.updateProfile({
+						userDTO: {
+							userName: profile.userName ?? '',
+							userGroupName: profile.userGroup as UserGroupDTO,
+							passwd: payload.password,
+						},
+					}),
+				),
+			),
+		).catch((error) => thunkApi.rejectWithValue(error.response)),
+);
 
 export const setForgotPasswordThunk = createAsyncThunk(
 	'main/setForgotPasswordThunk',


### PR DESCRIPTION
## OP-896 — Password lease (web UI)

Enforces the mandatory password change in the React web UI.

### Changes
- When the login response carries `mustChangePassword`, the user is redirected to a new `/change-password` screen.
- The `Private` route guard keeps the user on the change-password screen until the password is changed, then clears the flag and lets them proceed to the landing page.
- `mustChangePassword` added to the login OpenAPI schema (`api/oh.yaml`) and the generated client; the flag is persisted across reloads and defaulted in the auth mock.
- New `changepassword` i18n strings (English).

Relies on the paired api PR informatici/openhospital-api#585. Part of the OP-896 multi-repo change.

JIRA: https://openhospital.atlassian.net/browse/OP-896
