### PR TITLE
OP-1342 Send the bearer token on logout so the API can revoke it

### DIFF
--- a/src/state/main/thunk.ts
+++ b/src/state/main/thunk.ts
@@ -17,6 +17,7 @@ import type { IAction } from '../types';
 import { setLogoutFailed, setLogoutLoading, setLogoutSuccess } from './slice';
 
 const loginApi = new LoginApi(customConfiguration(false));
+const logoutApi = new LoginApi(customConfiguration());
 const usersApi = new UsersApi(customConfiguration());
 const userSettingsApi = new UserSettingsApi(customConfiguration());
 
@@ -44,8 +45,7 @@ export const setLogout =
 	() =>
 	(dispatch: Dispatch<IAction<void, object>>): void => {
 		dispatch(setLogoutLoading());
-		SessionStorage.clear();
-		loginApi.logout().subscribe(
+		logoutApi.logout().subscribe(
 			(payload) => {
 				dispatch(getPatientsReset());
 				dispatch(getLabsReset());
@@ -60,6 +60,9 @@ export const setLogout =
 				dispatch(setLogoutFailed(error?.response));
 			},
 		);
+		// cleared after subscribe so applyTokenMiddleware can attach the bearer
+		// token, allowing the API to revoke it
+		SessionStorage.clear();
 	};
 
 export const setForgotPasswordThunk = createAsyncThunk(


### PR DESCRIPTION
See [OP-1342](https://openhospital.atlassian.net/browse/OP-1342). Companion to informatici/openhospital-api#594.

The logout call now goes through the authenticated API configuration, so `applyTokenMiddleware` attaches `Authorization: Bearer <token>` and the API can revoke the session's token family. `SessionStorage.clear()` moves after the `subscribe(...)` call: the request is dispatched synchronously on subscribe, so the token is captured before the storage is cleared. Login stays on the unauthenticated configuration.

Without this change the API-side revocation is a logged no-op for browser users (the API PR behaves exactly as today for an unmodified UI, so the two PRs can merge in any order).

Verified: tsc, biome, vitest (26/26) and production build all green; codegen produced no drift.


[OP-1342]: https://openhospital.atlassian.net/browse/OP-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ