### PR TITLE
OP-887 Add patient data export download

### DIFF
--- a/api/oh.yaml
+++ b/api/oh.yaml
@@ -767,6 +767,31 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /patients/{code}/export:
+    get:
+      tags:
+      - Patients
+      description: GDPR Art. 20 - Right to data portability
+      operationId: exportPatientData
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PatientExportDTO"
+            text/csv:
+              schema:
+                type: string
+      security:
+      - bearerAuth: []
   /patientconsensus/{patientId}:
     get:
       tags:
@@ -6295,6 +6320,64 @@ components:
       - docs
       - nurs
       - visitDuration
+    PatientExportDTO:
+      type: object
+      description: "Aggregate of a patient record and all the records connected to\
+        \ it, for GDPR Art. 20 (right to data portability) exports"
+      properties:
+        patient:
+          $ref: "#/components/schemas/PatientDTO"
+          description: The patient record
+        admissions:
+          type: array
+          description: The admissions of the patient
+          items:
+            $ref: "#/components/schemas/AdmissionDTO"
+        opds:
+          type: array
+          description: The OPD episodes of the patient
+          items:
+            $ref: "#/components/schemas/OpdDTO"
+        laboratories:
+          type: array
+          description: The laboratory exams of the patient
+          items:
+            $ref: "#/components/schemas/LaboratoryDTO"
+        therapies:
+          type: array
+          description: The therapies of the patient
+          items:
+            $ref: "#/components/schemas/TherapyRowDTO"
+        operations:
+          type: array
+          description: The operations of the patient
+          items:
+            $ref: "#/components/schemas/OperationRowDTO"
+        vaccines:
+          type: array
+          description: The vaccines of the patient
+          items:
+            $ref: "#/components/schemas/PatientVaccineDTO"
+        examinations:
+          type: array
+          description: The examinations of the patient
+          items:
+            $ref: "#/components/schemas/PatientExaminationDTO"
+        bills:
+          type: array
+          description: The bills of the patient
+          items:
+            $ref: "#/components/schemas/BillDTO"
+        billItems:
+          type: array
+          description: The items of the patient's bills
+          items:
+            $ref: "#/components/schemas/BillItemsDTO"
+        billPayments:
+          type: array
+          description: The payments of the patient's bills
+          items:
+            $ref: "#/components/schemas/BillPaymentsDTO"
     PatientDTO:
       type: object
       description: Class representing a patient

--- a/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
+++ b/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
@@ -1,7 +1,12 @@
-import { EditRounded, Notes, Person } from '@mui/icons-material';
+import {
+	EditRounded,
+	FileDownloadRounded,
+	Notes,
+	Person,
+} from '@mui/icons-material';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
 	Navigate,
@@ -11,11 +16,15 @@ import {
 	useOutletContext,
 	useParams,
 } from 'react-router';
+import { firstValueFrom } from 'rxjs';
+import { wrapper } from '~/libraries/apiUtils/wrapper';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import { PATHS } from '../../../consts';
-import { PatientDTOStatusEnum } from '../../../generated';
+import { PatientDTOStatusEnum, PatientsApi } from '../../../generated';
+import { customConfiguration } from '../../../libraries/apiUtils/configuration';
 import { renderDate } from '../../../libraries/formatUtils/dataFormatting';
 import { Permission } from '../../../libraries/permissionUtils/Permission';
+import { downloadJsonFile } from '../../../libraries/uiUtils/downloadFile';
 import { scrollToElement } from '../../../libraries/uiUtils/scrollToElement';
 import { getPatient, getPatientReset } from '../../../state/patients';
 import {
@@ -27,6 +36,7 @@ import AppHeader from '../../accessories/appHeader/AppHeader';
 import Button from '../../accessories/button/Button';
 import Footer from '../../accessories/footer/Footer';
 import { HospitalInfo } from '../../accessories/hospitalInfo/HospitalInfo';
+import InfoBox from '../../accessories/infoBox/InfoBox';
 import { ProfilePicture } from '../../accessories/profilePicture/ProfilePicture';
 import InPatientDashboardMenu from './InPatientDashboardMenu';
 import OutPatientDashboardMenu from './OutPatientDashboardMenu';
@@ -34,6 +44,31 @@ import './styles.scss';
 import type { IUserSection, TActivityTransitionState } from './types';
 
 type ContextType = { status: string | null };
+
+const patientsApi = new PatientsApi(customConfiguration());
+
+const usePatientDataExport = (code: number | undefined) => {
+	const [exportStatus, setExportStatus] = useState<'IDLE' | 'LOADING' | 'FAIL'>(
+		'IDLE',
+	);
+
+	const exportPatientData = useCallback(() => {
+		if (code === undefined) {
+			return;
+		}
+		setExportStatus('LOADING');
+		firstValueFrom(wrapper(() => patientsApi.exportPatientData({ code })))
+			.then((exportData) => {
+				downloadJsonFile(`patient_${code}_export.json`, exportData);
+				setExportStatus('IDLE');
+			})
+			.catch(() => {
+				setExportStatus('FAIL');
+			});
+	}, [code]);
+
+	return { exportPatientData, exportStatus };
+};
 
 const PatientDetailsActivity = () => {
 	const dispatch = useAppDispatch();
@@ -85,6 +120,10 @@ const PatientDetailsActivity = () => {
 	const handleOnExpanded = (section: string) => {
 		setExpanded(section === expanded ? false : section);
 	};
+
+	const { exportPatientData, exportStatus } = usePatientDataExport(
+		patient.data?.code,
+	);
 
 	const personalData = (
 		<>
@@ -259,6 +298,33 @@ const PatientDetailsActivity = () => {
 														<span>{t('patient.titleedit')}</span>
 													</Button>
 												</div>
+											</div>
+										</Permission>
+
+										<Permission require="patient.export">
+											<div className="patientDetails__personalData_edit_button_wrapper">
+												<div className="patientDetails__personalData_edit_button">
+													<Button
+														type="button"
+														variant="contained"
+														color="primary"
+														dataCy="export-patient-data"
+														disabled={exportStatus === 'LOADING'}
+														onClick={exportPatientData}
+													>
+														<FileDownloadRounded
+															fontSize="small"
+															style={{ color: 'white' }}
+														/>
+														<span>{t('patient.exportdata')}</span>
+													</Button>
+												</div>
+												{exportStatus === 'FAIL' && (
+													<InfoBox
+														type="error"
+														message={t('common.somethingwrong')}
+													/>
+												)}
 											</div>
 										</Permission>
 

--- a/src/libraries/uiUtils/downloadFile.ts
+++ b/src/libraries/uiUtils/downloadFile.ts
@@ -1,0 +1,13 @@
+export const downloadJsonFile = (filename: string, data: unknown): void => {
+	const blob = new Blob([JSON.stringify(data, null, 2)], {
+		type: 'application/json',
+	});
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement('a');
+	link.href = url;
+	link.download = filename;
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	URL.revokeObjectURL(url);
+};

--- a/src/mocks/fixtures/patientExport.ts
+++ b/src/mocks/fixtures/patientExport.ts
@@ -1,0 +1,36 @@
+import type { PatientExportDTO, PatientVaccineDTO } from '../../generated';
+import { admissionDTO } from './admissionDTO';
+import { billDTO } from './billDTO';
+import billItemDTO from './billItemDTO';
+import billPaymentsDTO from './billPaymentsDTO';
+import { laboratoryDTO } from './laboratoryDTO';
+import { opdDTO } from './opdDTO';
+import { operationRowsDTO } from './operationRowsDTO';
+import patientDTO from './patientDTO';
+import { patientExaminationDTO } from './patientExaminationDTO';
+import { therapyRowDTO } from './therapyRowDTO';
+import { vaccineDTO } from './vaccineDTO';
+
+const patientVaccineDTO: PatientVaccineDTO = {
+	code: 1,
+	progr: 1,
+	vaccineDate: '2021-08-05T15:19:44.000Z',
+	patient: patientDTO,
+	vaccine: vaccineDTO[0],
+};
+
+export const patientExportDTO: PatientExportDTO = {
+	patient: patientDTO,
+	admissions: [admissionDTO],
+	opds: [opdDTO],
+	laboratories: laboratoryDTO,
+	therapies: [therapyRowDTO],
+	operations: operationRowsDTO,
+	vaccines: [patientVaccineDTO],
+	examinations: [patientExaminationDTO],
+	bills: [billDTO],
+	billItems: [billItemDTO],
+	billPayments: [billPaymentsDTO],
+};
+
+export default patientExportDTO;

--- a/src/mocks/fixtures/permissionList.ts
+++ b/src/mocks/fixtures/permissionList.ts
@@ -93,6 +93,7 @@ export const permissionList: string[] = [
 	'patientconsensus.read',
 	'patientconsensus.update',
 	'patientconsensus.delete',
+	'patient.export',
 	'patients.create',
 	'patients.read',
 	'patients.update',

--- a/src/mocks/routes/patients.ts
+++ b/src/mocks/routes/patients.ts
@@ -1,6 +1,7 @@
 import type { PollyServer } from '@pollyjs/core';
 import patientDTO, { patientDTO2 } from '../fixtures/patientDTO';
 import patientDTOOut from '../fixtures/patientDTOOut';
+import patientExportDTO from '../fixtures/patientExport';
 
 export const patientRoutes = (server: PollyServer) => {
 	server.namespace('/patients', () => {
@@ -13,6 +14,20 @@ export const patientRoutes = (server: PollyServer) => {
 				default:
 					res.status(201).json({ ...body, code: 1 });
 					break;
+			}
+		});
+
+		server.get('/:code/export').intercept((req, res) => {
+			const code = req.params.code;
+			switch (code) {
+				case '1234561':
+					res.status(400);
+					break;
+				default:
+					res.status(200).json({
+						...patientExportDTO,
+						patient: { ...patientDTO, code },
+					});
 			}
 		});
 

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -219,7 +219,8 @@
 		"created": "Patient created",
 		"updatesuccessful": "The patient was edit successfully.",
 		"createother": "Add Another Patient",
-		"status": "Status"
+		"status": "Status",
+		"exportdata": "Export patient data"
 	},
 	"opd": {
 		"newopd": "Create new OPD Visit",

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,7 @@ export type TPermission =
 	| 'patientconsensus.read'
 	| 'patientconsensus.update'
 	| 'patientconsensus.delete'
+	| 'patient.export'
 	| 'patients.create'
 	| 'patients.read'
 	| 'patients.update'


### PR DESCRIPTION
See [OP-887](https://openhospital.atlassian.net/browse/OP-887). Depends on informatici/openhospital-core#1633 and informatici/openhospital-api#595.

Adds a permission-gated "Export patient data" action to the patient details view: it calls `GET /patients/{code}/export` and downloads the JSON as a file. Visible only to users holding `patient.export`.

Notes:
- `api/oh.yaml` carries the same export blocks as the API PR so the generated client includes the new endpoint. It intentionally still lags api develop by the unrelated `deletePatientExamination` endpoint (api#584) — say the word if you prefer a full re-sync in this PR.
- Generated client files stay gitignored (regenerated by the postinstall codegen), not committed.

Verified: tsc, biome, vitest and production build all green.


[OP-887]: https://openhospital.atlassian.net/browse/OP-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ