### PR TITLE
OP-886 Add patient anonymization to the web UI

### DIFF
--- a/api/oh.yaml
+++ b/api/oh.yaml
@@ -6459,6 +6459,10 @@ components:
           type: string
           description: Current anamnesis
           maxLength: 255
+        anonymized:
+          type: boolean
+          description: Whether the patient has been anonymized (GDPR right to erasure)
+          readOnly: true
         status:
           type: string
           description: Status

--- a/api/oh.yaml
+++ b/api/oh.yaml
@@ -6075,6 +6075,29 @@ paths:
                 type: boolean
       security:
       - bearerAuth: []
+  /patients/{code}/personal-data:
+    delete:
+      tags:
+      - Patients
+      summary: GDPR Art. 17 — Right to erasure. Irreversibly anonymize a patient's
+        personal data.
+      operationId: anonymizePatient
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
+      security:
+      - bearerAuth: []
   /operations/rows/{code}:
     delete:
       tags:

--- a/src/components/accessories/patientDataForm/PatientDataForm.tsx
+++ b/src/components/accessories/patientDataForm/PatientDataForm.tsx
@@ -51,6 +51,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 	shouldResetForm,
 	resetFormCallback,
 	mode = 'create',
+	anonymized = false,
 }) => {
 	const { t } = useTranslation();
 	const dispatch = useAppDispatch();
@@ -220,7 +221,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 		<div data-cy="patient-data-form" className="patientDataForm">
 			<div className="patientDataForm__profilePictureContainer">
 				<ProfilePicture
-					isEditable={!isLoading}
+					isEditable={!isLoading && !anonymized}
 					preLoadedPicture={profilePicture}
 					onChange={onProfilePictureChange}
 					shouldReset={shouldResetForm}
@@ -237,7 +238,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('firstName')}
 							errorText={getErrorText('firstName')}
 							onBlur={formik.handleBlur}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'firstName')
 									? FIELD_VALIDATION.SUGGESTED
@@ -254,7 +255,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('secondName')}
 							errorText={getErrorText('secondName')}
 							onBlur={formik.handleBlur}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'secondName')
 									? FIELD_VALIDATION.SUGGESTED
@@ -272,7 +273,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('taxCode')}
 							errorText={getErrorText('taxCode')}
 							onBlur={formik.handleBlur}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'taxCode')
 									? FIELD_VALIDATION.SUGGESTED
@@ -294,7 +295,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							onBlur={onBlurCallback('sex')}
 							options={options.sex}
 							translateOptions={true}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'sex')
 									? FIELD_VALIDATION.SUGGESTED
@@ -316,7 +317,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 								setAgeType(value as TAgeFieldName);
 							}}
 							options={ageTypeOptions}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={FIELD_VALIDATION.SUGGESTED}
 						/>
 					</div>
@@ -331,7 +332,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 								onBlur={onBlurCallback('agetype')}
 								options={ageRangeOptions ?? []}
 								translateOptions={true}
-								disabled={isLoading}
+								disabled={isLoading || anonymized}
 								required={
 									isFieldSuggested(formCustomization, 'agetype')
 										? FIELD_VALIDATION.SUGGESTED
@@ -349,7 +350,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 								isValid={isValid('age')}
 								errorText={getErrorText('age')}
 								onBlur={formik.handleBlur}
-								disabled={isLoading}
+								disabled={isLoading || anonymized}
 								type="number"
 								required={
 									isFieldSuggested(formCustomization, 'age')
@@ -371,7 +372,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 								errorText={getErrorText('birthDate')}
 								label={t('patient.birthdate')}
 								onChange={dateFieldHandleOnChange('birthDate')}
-								disabled={isLoading}
+								disabled={isLoading || anonymized}
 								required={
 									isFieldSuggested(formCustomization, 'birthDate')
 										? FIELD_VALIDATION.SUGGESTED
@@ -390,7 +391,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('bloodType')}
 							errorText={getErrorText('bloodType')}
 							options={options.bloodType}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'bloodType')
 									? FIELD_VALIDATION.SUGGESTED
@@ -409,7 +410,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('motherName')}
 							errorText={getErrorText('motherName')}
 							onBlur={formik.handleBlur}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'motherName')
 									? FIELD_VALIDATION.SUGGESTED
@@ -427,7 +428,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('fatherName')}
 							errorText={getErrorText('fatherName')}
 							onBlur={formik.handleBlur}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'fatherName')
 									? FIELD_VALIDATION.SUGGESTED
@@ -447,7 +448,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							onBlur={onBlurCallback('parentTogether')}
 							options={options.parentTogether}
 							translateOptions={true}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'parentTogether')
 									? FIELD_VALIDATION.SUGGESTED
@@ -466,7 +467,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('address')}
 							errorText={getErrorText('address')}
 							onBlur={formik.handleBlur}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'address')
 									? FIELD_VALIDATION.SUGGESTED
@@ -485,7 +486,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							errorText={getErrorText('city')}
 							onBlur={onBlurCallback('city')}
 							options={cityOptions ?? []}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							freeSolo={true}
 							autoSelect={true}
 							clearOnBlur={true}
@@ -506,7 +507,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									errorText={getErrorText('telephone')}
 									onBlur={formik.handleBlur}
 									type="tel"
-									disabled={isLoading}
+									disabled={isLoading || anonymized}
 									required={
 										isFieldSuggested(formCustomization, 'telephone')
 											? FIELD_VALIDATION.SUGGESTED
@@ -530,7 +531,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							onBlur={onBlurCallback('hasInsurance')}
 							options={options.hasInsurance}
 							translateOptions={true}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'hasInsurance')
 									? FIELD_VALIDATION.SUGGESTED
@@ -550,7 +551,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							isValid={isValid('note')}
 							errorText={getErrorText('note')}
 							onBlur={formik.handleBlur}
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							required={
 								isFieldSuggested(formCustomization, 'note')
 									? FIELD_VALIDATION.SUGGESTED
@@ -572,7 +573,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 						<Button
 							type="submit"
 							variant="contained"
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							dataCy="patient-data-submit-button"
 						>
 							{submitButtonLabel}
@@ -582,7 +583,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 						<Button
 							type="reset"
 							variant="text"
-							disabled={isLoading}
+							disabled={isLoading || anonymized}
 							onClick={() => setOpenResetConfirmation(true)}
 							dataCy="patient-data-cancel-button"
 						>

--- a/src/components/accessories/patientDataForm/types.ts
+++ b/src/components/accessories/patientDataForm/types.ts
@@ -6,6 +6,8 @@ interface IOwnProps {
 	shouldResetForm: boolean;
 	resetFormCallback: () => void;
 	mode: 'create' | 'edit';
+	/** When the edited patient is anonymized (GDPR erasure) the personal-data fields are read-only. */
+	anonymized?: boolean;
 }
 
 export type TAgeFieldName = 'age' | 'agetype' | 'birthDate';

--- a/src/components/activities/editPatientActivity/EditPatientActivity.tsx
+++ b/src/components/activities/editPatientActivity/EditPatientActivity.tsx
@@ -150,6 +150,7 @@ export const EditPatientActivity = () => {
 									shouldResetForm={shouldResetForm}
 									resetFormCallback={resetFormCallback}
 									mode={'edit'}
+									anonymized={patient.data?.anonymized}
 								/>
 								<div ref={infoBoxRef}>
 									{hasFailed && <InfoBox type="error" message={errorMessage} />}

--- a/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
+++ b/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
@@ -290,7 +290,7 @@ const PatientDetailsActivity = () => {
 													<Button
 														type="button"
 														variant="contained"
-														color="secondary"
+														color="error"
 														onClick={() => setAnonymizeOpen(true)}
 													>
 														<span>{t('patient.anonymize.button')}</span>

--- a/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
+++ b/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
@@ -12,12 +12,17 @@ import {
 	useParams,
 } from 'react-router';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
+import warningIcon from '../../../assets/warning-icon.png';
 import { PATHS } from '../../../consts';
 import { PatientDTOStatusEnum } from '../../../generated';
 import { renderDate } from '../../../libraries/formatUtils/dataFormatting';
 import { Permission } from '../../../libraries/permissionUtils/Permission';
 import { scrollToElement } from '../../../libraries/uiUtils/scrollToElement';
-import { getPatient, getPatientReset } from '../../../state/patients';
+import {
+	anonymizePatient,
+	getPatient,
+	getPatientReset,
+} from '../../../state/patients';
 import {
 	Accordion,
 	AccordionDetails,
@@ -25,6 +30,7 @@ import {
 } from '../../accessories/accordion/Accordion';
 import AppHeader from '../../accessories/appHeader/AppHeader';
 import Button from '../../accessories/button/Button';
+import ConfirmationDialog from '../../accessories/confirmationDialog/ConfirmationDialog';
 import Footer from '../../accessories/footer/Footer';
 import { HospitalInfo } from '../../accessories/hospitalInfo/HospitalInfo';
 import { ProfilePicture } from '../../accessories/profilePicture/ProfilePicture';
@@ -72,6 +78,22 @@ const PatientDetailsActivity = () => {
 	const [activityTransitionState, setActivityTransitionState] =
 		useState<TActivityTransitionState>('IDLE');
 	const [isOpen, setIsOpen] = useState(false);
+	const [anonymizeOpen, setAnonymizeOpen] = useState(false);
+
+	const handleAnonymize = () => {
+		const code = patient.data?.code;
+		if (code === undefined) {
+			return;
+		}
+		dispatch(anonymizePatient({ code }))
+			.unwrap()
+			.then(() => {
+				setAnonymizeOpen(false);
+				dispatch(getPatient(String(code)));
+			})
+			.catch(() => setAnonymizeOpen(false));
+	};
+
 	const location = useLocation();
 	const section =
 		location.pathname.split('/')[location.pathname.split('/').length - 1];
@@ -261,6 +283,32 @@ const PatientDetailsActivity = () => {
 												</div>
 											</div>
 										</Permission>
+
+										<Permission require="patient.anonymize">
+											<div className="patientDetails__personalData_edit_button_wrapper">
+												<div className="patientDetails__personalData_edit_button">
+													<Button
+														type="button"
+														variant="contained"
+														color="secondary"
+														onClick={() => setAnonymizeOpen(true)}
+													>
+														<span>{t('patient.anonymize.button')}</span>
+													</Button>
+												</div>
+											</div>
+										</Permission>
+
+										<ConfirmationDialog
+											isOpen={anonymizeOpen}
+											title={t('patient.anonymize.title')}
+											icon={warningIcon}
+											info={t('patient.anonymize.info')}
+											primaryButtonLabel={t('patient.anonymize.button')}
+											secondaryButtonLabel={t('common.cancel')}
+											handlePrimaryButtonClick={handleAnonymize}
+											handleSecondaryButtonClick={() => setAnonymizeOpen(false)}
+										/>
 
 										<div className="patientDetails_status">
 											{patient?.data?.status === PatientDTOStatusEnum.I ? (

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -153,6 +153,11 @@
 		"emptylayout": "No displayed widget. Start by adding widgets"
 	},
 	"patient": {
+		"anonymize": {
+			"button": "Anonymize",
+			"title": "Anonymize patient",
+			"info": "This will irreversibly anonymize the personal data of this patient. The clinical records are kept and this action cannot be undone. Proceed?"
+		},
 		"address": "Address",
 		"birthdate": "Birth Date",
 		"bloodtype": "Blood type",

--- a/src/state/patients/thunk.ts
+++ b/src/state/patients/thunk.ts
@@ -4,6 +4,7 @@ import { firstValueFrom } from 'rxjs';
 import { wrapper } from '~/libraries/apiUtils/wrapper';
 import type { TValues } from '../../components/activities/searchPatientActivity/types';
 import {
+	type AnonymizePatientRequest,
 	type PatientDTO,
 	PatientsApi,
 	type UpdatePatientRequest,
@@ -77,5 +78,13 @@ export const updatePatient = createAsyncThunk(
 	async (payload: UpdatePatientRequest, thunkApi) =>
 		firstValueFrom(wrapper(() => api.updatePatient(payload))).catch((error) =>
 			thunkApi.rejectWithValue(error.response),
+		),
+);
+
+export const anonymizePatient = createAsyncThunk(
+	'patients/anonymizePatient',
+	async (payload: AnonymizePatientRequest, thunkApi) =>
+		firstValueFrom(wrapper(() => api.anonymizePatient(payload))).catch(
+			(error) => thunkApi.rejectWithValue(error.response),
 		),
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,7 @@ export type TPermission =
 	| 'patients.read'
 	| 'patients.update'
 	| 'patients.delete'
+	| 'patient.anonymize'
 	| 'patientvaccines.create'
 	| 'patientvaccines.read'
 	| 'patientvaccines.update'


### PR DESCRIPTION
Web UI part of **OP-886 – GDPR 1/4 Oblivion (Art. 17, right to erasure)**.

### Changes
- An **Anonymize** action in the patient details view (shown only with the `patient.anonymize` permission) with an irreversible-action confirmation dialog; calls `DELETE /patients/{code}/personal-data` (`anonymizePatient` thunk) and reloads the patient.
- `'patient.anonymize'` added to `TPermission`; `patient.anonymize.*` i18n; `api/oh.yaml` synced (the generated client is rebuilt from it at build time).

Depends on **api informatici/openhospital-api#602** (and, transitively, core #1641). Merge order: core → api → ui.

Verified end-to-end against a running API + MariaDB 10.6 demo DB (patient anonymized from the web UI, no errors).
