### PR TITLE
OH2-480 Add first baseline for UI mobile testing

### DIFF
--- a/.github/workflows/mobile-audit.yml
+++ b/.github/workflows/mobile-audit.yml
@@ -1,0 +1,26 @@
+name: Mobile Audit
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  mobile-audit:
+    name: Mobile audit (allowed failure)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Cypress mobile audit
+        uses: cypress-io/github-action@v6
+        with:
+          browser: chrome
+          record: false
+          start: npm run start:ci
+          wait-on: "http://localhost:5173"
+          spec: cypress/integrations/mobile_baseline_audit.cy.ts
+        env:
+          CYPRESS_MOBILE_AUDIT: true
+          CYPRESS_MOBILE_AUDIT_VIEWPORT: phone-modern

--- a/cypress/integrations/mobile_baseline_audit.cy.ts
+++ b/cypress/integrations/mobile_baseline_audit.cy.ts
@@ -16,8 +16,9 @@ type AuditRoute = {
 
 const auditEnabled = Boolean(Cypress.env('MOBILE_AUDIT'));
 const describeAudit = auditEnabled ? describe : describe.skip;
-const viewportFilter = Cypress.env('MOBILE_AUDIT_VIEWPORT');
+const viewportFilter = Cypress.env('MOBILE_AUDIT_VIEWPORT') || 'phone-modern';
 const routeFilter = Cypress.env('MOBILE_AUDIT_ROUTE');
+const maxAllowedHorizontalOverflow = 1;
 
 const viewports: AuditViewport[] = [
 	{ name: 'phone-small', width: 360, height: 740 },
@@ -78,7 +79,7 @@ const routes: AuditRoute[] = [
 ];
 
 const selectedViewports = viewports.filter((viewport) => {
-	return !viewportFilter || viewport.name === viewportFilter;
+	return viewportFilter === 'all' || viewport.name === viewportFilter;
 });
 
 const selectedRoutes = routes.filter((route) => {
@@ -94,22 +95,65 @@ const visitRoute = (route: AuditRoute) => {
 	cy.visit(route.path);
 };
 
-const logMobileMeasurements = () => {
+const assertPageFitsMobileViewport = () => {
 	cy.window().then((win) => {
 		const doc = win.document.documentElement;
 		const body = win.document.body;
 		const scrollWidth = Math.max(doc.scrollWidth, body.scrollWidth);
 		const clientWidth = doc.clientWidth;
-		const scrollHeight = Math.max(doc.scrollHeight, body.scrollHeight);
-		const clientHeight = doc.clientHeight;
 		const horizontalOverflow = scrollWidth - clientWidth;
-		const verticalOverflow = scrollHeight - clientHeight;
-		const bodyOverflow = win.getComputedStyle(body).overflow;
 
-		cy.log(`horizontal overflow: ${horizontalOverflow}px`);
-		cy.log(`vertical overflow: ${verticalOverflow}px`);
-		cy.log(`body overflow: ${bodyOverflow}`);
+		expect(
+			horizontalOverflow,
+			'page should not overflow horizontally on mobile',
+		).to.be.at.most(maxAllowedHorizontalOverflow);
 	});
+};
+
+const assertPageIsNotScrollLocked = () => {
+	cy.window().then((win) => {
+		const body = win.document.body;
+		const bodyOverflowY = win.getComputedStyle(body).overflowY;
+
+		expect(
+			body.classList.contains('disable-scroll'),
+			'body should not keep the mobile menu scroll lock',
+		).to.eq(false);
+		expect(
+			bodyOverflowY,
+			'body vertical scrolling should not be blocked',
+		).to.not.eq('hidden');
+	});
+};
+
+const assertPrimaryElementFitsMobileViewport = (selector: string) => {
+	cy.window().then((win) => {
+		cy.get(selector).then(($element) => {
+			const rect = $element[0].getBoundingClientRect();
+			const viewportWidth = win.innerWidth;
+
+			expect(
+				rect.left,
+				'primary content should not start off-screen',
+			).to.be.at.least(-maxAllowedHorizontalOverflow);
+			expect(
+				rect.right,
+				'primary content should not end off-screen',
+			).to.be.at.most(viewportWidth + maxAllowedHorizontalOverflow);
+		});
+	});
+};
+
+const assertMobileHeaderStartsClosed = () => {
+	cy.get('.appHeader').should('be.visible');
+	cy.get('.appHeader').should('not.have.class', 'open_menu');
+	cy.get('body').should('not.have.class', 'disable-scroll');
+};
+
+const assertMobileNavigationTriggerIsUsable = () => {
+	cy.dataCy('app-header-identified-trigger')
+		.should('be.visible')
+		.and('not.be.disabled');
 };
 
 describeAudit('Mobile baseline audit', () => {
@@ -120,10 +164,18 @@ describeAudit('Mobile baseline audit', () => {
 			});
 
 			selectedRoutes.forEach((route) => {
-				it(`captures ${route.name}`, () => {
+				it(`renders ${route.name} without basic mobile layout regressions`, () => {
 					visitRoute(route);
 					cy.get(route.selector, { timeout: 15000 }).should('be.visible');
-					logMobileMeasurements();
+					assertPageFitsMobileViewport();
+					assertPageIsNotScrollLocked();
+					assertPrimaryElementFitsMobileViewport(route.selector);
+
+					if (route.authenticated) {
+						assertMobileHeaderStartsClosed();
+						assertMobileNavigationTriggerIsUsable();
+					}
+
 					cy.screenshot(
 						`mobile-baseline/${viewport.name}/${route.order}-${route.name}`,
 						{
@@ -133,7 +185,32 @@ describeAudit('Mobile baseline audit', () => {
 				});
 			});
 
-			it('captures mobile menu navigation behavior', () => {
+			it('opens and closes the mobile menu with the header trigger', () => {
+				visitRoute({
+					order: '02',
+					name: 'dashboard',
+					path: '/dashboard',
+					selector: '[data-cy=dashboard]',
+					authenticated: true,
+				});
+
+				assertMobileHeaderStartsClosed();
+				assertMobileNavigationTriggerIsUsable();
+
+				cy.dataCy('app-header-identified-trigger').click();
+				cy.get('.appHeader').should('have.class', 'open_menu');
+				cy.get('body').should('have.class', 'disable-scroll');
+
+				cy.dataCy('app-header-identified-trigger').click();
+				cy.get('.appHeader').should('not.have.class', 'open_menu');
+				cy.get('body').should('not.have.class', 'disable-scroll');
+
+				cy.screenshot(`mobile-baseline/${viewport.name}/08-menu-toggle`, {
+					capture: 'viewport',
+				});
+			});
+
+			it('closes the mobile menu after navigation', () => {
 				visitRoute({
 					order: '02',
 					name: 'dashboard',
@@ -147,23 +224,11 @@ describeAudit('Mobile baseline audit', () => {
 				cy.get('body').should('have.class', 'disable-scroll');
 				cy.contains('.appHeader__nav__item', 'Patients').click();
 				cy.location('pathname').should('eq', '/patients');
-
-				cy.get('.appHeader').then(($header) => {
-					cy.log(
-						`menu remains open after navigation: ${$header.hasClass('open_menu')}`,
-					);
-				});
-
-				cy.get('body').then(($body) => {
-					cy.log(
-						`body remains scroll-locked after navigation: ${$body.hasClass(
-							'disable-scroll',
-						)}`,
-					);
-				});
+				cy.get('.appHeader').should('not.have.class', 'open_menu');
+				cy.get('body').should('not.have.class', 'disable-scroll');
 
 				cy.screenshot(
-					`mobile-baseline/${viewport.name}/08-menu-after-navigation`,
+					`mobile-baseline/${viewport.name}/09-menu-after-navigation`,
 					{
 						capture: 'viewport',
 					},

--- a/cypress/integrations/mobile_baseline_audit.cy.ts
+++ b/cypress/integrations/mobile_baseline_audit.cy.ts
@@ -1,0 +1,174 @@
+/// <reference types="cypress" />
+
+type AuditViewport = {
+	name: string;
+	width: number;
+	height: number;
+};
+
+type AuditRoute = {
+	order: string;
+	name: string;
+	path: string;
+	selector: string;
+	authenticated?: boolean;
+};
+
+const auditEnabled = Boolean(Cypress.env('MOBILE_AUDIT'));
+const describeAudit = auditEnabled ? describe : describe.skip;
+const viewportFilter = Cypress.env('MOBILE_AUDIT_VIEWPORT');
+const routeFilter = Cypress.env('MOBILE_AUDIT_ROUTE');
+
+const viewports: AuditViewport[] = [
+	{ name: 'phone-small', width: 360, height: 740 },
+	{ name: 'phone-modern', width: 390, height: 844 },
+	{ name: 'fairphone-4', width: 411, height: 756 },
+	{ name: 'tablet-portrait', width: 768, height: 1024 },
+];
+
+const routes: AuditRoute[] = [
+	{
+		order: '01',
+		name: 'login',
+		path: '/login',
+		selector: '[data-cy=login-panel]',
+	},
+	{
+		order: '02',
+		name: 'dashboard',
+		path: '/dashboard',
+		selector: '[data-cy=dashboard]',
+		authenticated: true,
+	},
+	{
+		order: '03',
+		name: 'patient-search',
+		path: '/patients/search',
+		selector: '[data-cy=search-patient]',
+		authenticated: true,
+	},
+	{
+		order: '04',
+		name: 'patient-details',
+		path: '/patients/details/1234563',
+		selector: '[data-cy=patient-details]',
+		authenticated: true,
+	},
+	{
+		order: '05',
+		name: 'visits',
+		path: '/visits',
+		selector: '.visits',
+		authenticated: true,
+	},
+	{
+		order: '06',
+		name: 'laboratory',
+		path: '/laboratory',
+		selector: '.labs',
+		authenticated: true,
+	},
+	{
+		order: '07',
+		name: 'admin',
+		path: '/admin',
+		selector: '[data-cy=admin-activity]',
+		authenticated: true,
+	},
+];
+
+const selectedViewports = viewports.filter((viewport) => {
+	return !viewportFilter || viewport.name === viewportFilter;
+});
+
+const selectedRoutes = routes.filter((route) => {
+	return !routeFilter || route.name === routeFilter;
+});
+
+const visitRoute = (route: AuditRoute) => {
+	if (route.authenticated) {
+		cy.authenticate(route.path);
+		return;
+	}
+
+	cy.visit(route.path);
+};
+
+const logMobileMeasurements = () => {
+	cy.window().then((win) => {
+		const doc = win.document.documentElement;
+		const body = win.document.body;
+		const scrollWidth = Math.max(doc.scrollWidth, body.scrollWidth);
+		const clientWidth = doc.clientWidth;
+		const scrollHeight = Math.max(doc.scrollHeight, body.scrollHeight);
+		const clientHeight = doc.clientHeight;
+		const horizontalOverflow = scrollWidth - clientWidth;
+		const verticalOverflow = scrollHeight - clientHeight;
+		const bodyOverflow = win.getComputedStyle(body).overflow;
+
+		cy.log(`horizontal overflow: ${horizontalOverflow}px`);
+		cy.log(`vertical overflow: ${verticalOverflow}px`);
+		cy.log(`body overflow: ${bodyOverflow}`);
+	});
+};
+
+describeAudit('Mobile baseline audit', () => {
+	selectedViewports.forEach((viewport) => {
+		context(`${viewport.name} (${viewport.width}x${viewport.height})`, () => {
+			beforeEach(() => {
+				cy.viewport(viewport.width, viewport.height);
+			});
+
+			selectedRoutes.forEach((route) => {
+				it(`captures ${route.name}`, () => {
+					visitRoute(route);
+					cy.get(route.selector, { timeout: 15000 }).should('be.visible');
+					logMobileMeasurements();
+					cy.screenshot(
+						`mobile-baseline/${viewport.name}/${route.order}-${route.name}`,
+						{
+							capture: 'viewport',
+						},
+					);
+				});
+			});
+
+			it('captures mobile menu navigation behavior', () => {
+				visitRoute({
+					order: '02',
+					name: 'dashboard',
+					path: '/dashboard',
+					selector: '[data-cy=dashboard]',
+					authenticated: true,
+				});
+
+				cy.dataCy('app-header-identified-trigger').click();
+				cy.get('.appHeader').should('have.class', 'open_menu');
+				cy.get('body').should('have.class', 'disable-scroll');
+				cy.contains('.appHeader__nav__item', 'Patients').click();
+				cy.location('pathname').should('eq', '/patients');
+
+				cy.get('.appHeader').then(($header) => {
+					cy.log(
+						`menu remains open after navigation: ${$header.hasClass('open_menu')}`,
+					);
+				});
+
+				cy.get('body').then(($body) => {
+					cy.log(
+						`body remains scroll-locked after navigation: ${$body.hasClass(
+							'disable-scroll',
+						)}`,
+					);
+				});
+
+				cy.screenshot(
+					`mobile-baseline/${viewport.name}/08-menu-after-navigation`,
+					{
+						capture: 'viewport',
+					},
+				);
+			});
+		});
+	});
+});


### PR DESCRIPTION
See OH2-475 for general context.
See OH2-480 for this change.

## Summary
Adds an opt-in Cypress mobile baseline audit for the UI.

The audit uses `phone-modern` as the default viewport and includes baseline assertions for common mobile regressions:
- no horizontal document overflow;
- no unexpected body scroll lock;
- no blocked vertical body scrolling;
- primary page content must fit within the mobile viewport;
- authenticated pages must show a usable mobile header trigger;
- the mobile menu must open and close from the header trigger;
- the mobile menu must close after navigation.

A separate `Mobile Audit` GitHub Action runs this Cypress spec in Chrome with `continue-on-error: true`, without uploading screenshots.

## Notes
The audit may fail while existing mobile regressions are still present. This is expected: the goal is to make mobile failures visible without blocking unrelated pull requests.

## How to run
```
npx start-server-and-test start:ci http://localhost:5173 "cypress run --browser chrome --spec cypress/integrations/mobile_baseline_audit.cy.ts --env MOBILE_AUDIT=true"
```