### PR TITLE
OP-1432 Do not prompt to discard after a successful edit-user save

### DIFF
--- a/src/components/accessories/admin/users/editUser/EditUserForm.tsx
+++ b/src/components/accessories/admin/users/editUser/EditUserForm.tsx
@@ -207,7 +207,8 @@ export const EditUserForm = ({
 				info={t('user.updatedSuccessMessage')}
 				primaryButtonLabel="Ok"
 				handlePrimaryButtonClick={() => {
-					navigate(PATHS.admin_users);
+					// replace (not push) so the dirty-form navigation guard does not prompt to discard after a successful save
+					navigate(PATHS.admin_users, { replace: true });
 				}}
 				handleSecondaryButtonClick={() => ({})}
 			/>


### PR DESCRIPTION
Fixes OP-1432: https://openhospital.atlassian.net/browse/OP-1432

On the admin **Edit User** form, a successful save followed by OK still triggered the "Discard — all unsaved data will be lost" prompt: `EditUserForm` navigated to the users list with a **PUSH** while the form was still dirty, and the shared navigation guard (`useDiscardHelpers`) blocks every navigation except a `REPLACE`. The other admin forms (`WardForm`, `NewUser`) already navigate with `{ replace: true }`.

This adds `{ replace: true }` to the success navigation, matching the other forms, so after a successful save the user goes straight to the users list with no discard prompt.

**Repro (before):** Administration → Users & Groups → edit a user → change any field, leave the password blank → Save → OK → an unexpected "discard unsaved data" dialog appears.

Pre-existing and independent of the password-policy work (OP-1430); one-line change.
