### PR TITLE
OH2-483 Apply the safe Dependabot dependency bumps and auto-fixable runtime transitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"immer": "^11.0.1",
 				"jquery": "^3.7.1",
 				"jwt-decode": "^4.0.0",
-				"lodash": "^4.17.21",
+				"lodash": "^4.18.1",
 				"moment": "^2.30.1",
 				"node-fetch": "^3.3.2",
 				"numbro": "^2.5.0",
@@ -51,8 +51,8 @@
 				"react-image-crop": "^11.0.10",
 				"react-number-format": "^5.4.4",
 				"react-redux": "^9.2.0",
-				"react-router": "^7.10.1",
-				"react-router-dom": "^7.10.1",
+				"react-router": "^7.15.0",
+				"react-router-dom": "^7.15.0",
 				"react-webcam": "^7.2.0",
 				"redux": "^5.0.1",
 				"redux-thunk": "^3.1.0",
@@ -9493,12 +9493,15 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.21",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.once": {
@@ -10480,9 +10483,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.49",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-			"integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+			"version": "8.5.19",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+			"integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -10499,7 +10502,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.7",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -10902,9 +10905,9 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.10.1.tgz",
-			"integrity": "sha512-gHL89dRa3kwlUYtRQ+m8NmxGI6CgqN+k4XyGjwcFoQwwCWF6xXpOCUlDovkXClS0d0XJN/5q7kc5W3kiFEd0Yw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+			"integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
 			"license": "MIT",
 			"dependencies": {
 				"cookie": "^1.0.1",
@@ -10924,12 +10927,12 @@
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.10.1.tgz",
-			"integrity": "sha512-JNBANI6ChGVjA5bwsUIwJk7LHKmqB4JYnYfzFwyp2t12Izva11elds2jx7Yfoup2zssedntwU0oZ5DEmk5Sdaw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+			"integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
 			"license": "MIT",
 			"dependencies": {
-				"react-router": "7.10.1"
+				"react-router": "7.18.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -12665,35 +12668,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/vite/node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"nanoid": "^3.3.11",
-				"picocolors": "^1.1.1",
-				"source-map-js": "^1.2.1"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"immer": "^11.0.1",
 		"jquery": "^3.7.1",
 		"jwt-decode": "^4.0.0",
-		"lodash": "^4.17.21",
+		"lodash": "^4.18.1",
 		"moment": "^2.30.1",
 		"node-fetch": "^3.3.2",
 		"numbro": "^2.5.0",
@@ -73,8 +73,8 @@
 		"react-image-crop": "^11.0.10",
 		"react-number-format": "^5.4.4",
 		"react-redux": "^9.2.0",
-		"react-router": "^7.10.1",
-		"react-router-dom": "^7.10.1",
+		"react-router": "^7.15.0",
+		"react-router-dom": "^7.15.0",
 		"react-webcam": "^7.2.0",
 		"redux": "^5.0.1",
 		"redux-thunk": "^3.1.0",
@@ -85,6 +85,10 @@
 		"styled-components": "^6.1.19",
 		"susy": "2",
 		"yup": "^1.7.1"
+	},
+	"overrides": {
+		"lodash-es": "4.18.1",
+		"postcss": "8.5.19"
 	},
 	"eslintConfig": {
 		"extends": "react-app",


### PR DESCRIPTION
## What

Applies the safe dependency bumps flagged by Dependabot, plus the auto-fixable runtime transitives:

- `lodash` `^4.17.21` → `^4.18.1` (direct runtime)
- `react-router` / `react-router-dom` `^7.10.1` → `^7.15.0` (resolves 7.18.1)
- `overrides`: `lodash-es` → `4.18.1`, `postcss` → `8.5.19` (vulnerable pinned transitives)

`npm audit`: **48 → 42** vulnerabilities (−4 high, −2 moderate).

## Why

Part of the Dependabot vulnerability cleanup (OH2-482 epic). This ticket covers only the low-risk bumps; the remaining alerts are tracked separately: critical `jspdf` (OH2-484), DOMPurify XSS (OH2-485), dev/build tooling (OH2-486).

## Verification

- `tsc --noEmit` + `vite build` green
- unit tests (vitest): 26/26 green
- full Cypress e2e suite: all specs passed (345 passing, 14 pending, 0 failing)
- live navigation smoke on the bumped `react-router` (login redirect, all main routes, nested admin redirect, deep-link, history back)

## Notes

- Deferred with rationale: the flagged `immutable` instance comes via `sass` (dev-only → OH2-486); `yaml@1.10.2` is build-time via `cosmiconfig` (forcing `yaml@2` breaks it) — both out of scope here.

Jira: OH2-483
