### PR TITLE
OH2-475 Improve mobile usability: header menu navigation and mobile scroll/layout

### DIFF
--- a/cypress/integrations/mobile_usability.cy.ts
+++ b/cypress/integrations/mobile_usability.cy.ts
@@ -1,0 +1,70 @@
+/// <reference types="cypress" />
+
+describe('Mobile usability spec', () => {
+	beforeEach(() => {
+		cy.viewport(390, 844);
+	});
+
+	it('should close the mobile menu and restore scrolling when navigating', () => {
+		cy.authenticate('/dashboard');
+
+		cy.dataCy('app-header-identified-trigger').click();
+		cy.dataCy('app-header').should('have.class', 'open_menu');
+		cy.get('body').should('have.class', 'disable-scroll');
+
+		cy.get('.appHeader__nav__item').contains(/patients/i).click();
+
+		cy.url().should('include', '/patients');
+		cy.dataCy('app-header').should('not.have.class', 'open_menu');
+		cy.get('body').should('not.have.class', 'disable-scroll');
+	});
+
+	it('should close the mobile menu when tapping the nav item of the current route', () => {
+		cy.authenticate('/patients');
+
+		cy.dataCy('app-header-identified-trigger').click();
+		cy.dataCy('app-header').should('have.class', 'open_menu');
+		cy.get('body').should('have.class', 'disable-scroll');
+
+		// same-route navigation: the pathname does not change, the menu must close anyway
+		cy.get('.appHeader__nav__item').contains(/patients/i).click();
+
+		cy.url().should('include', '/patients');
+		cy.dataCy('app-header').should('not.have.class', 'open_menu');
+		cy.get('body').should('not.have.class', 'disable-scroll');
+	});
+
+	it('should close the mobile menu when navigating through the logo link', () => {
+		cy.authenticate('/patients');
+
+		cy.dataCy('app-header-identified-trigger').click();
+		cy.get('body').should('have.class', 'disable-scroll');
+
+		cy.get('.appHeader__identifier__logo a').click({ force: true });
+
+		cy.dataCy('app-header').should('not.have.class', 'open_menu');
+		cy.get('body').should('not.have.class', 'disable-scroll');
+	});
+
+	it('should keep the dashboard in natural document flow on a phone viewport', () => {
+		cy.authenticate('/dashboard');
+
+		cy.get('.dashboard').should(($el) => {
+			expect($el.css('position')).not.to.equal('absolute');
+			expect($el.css('min-height')).not.to.equal('0px');
+		});
+		cy.get('body').should('not.have.class', 'disable-scroll');
+	});
+
+	it('should let the patient search page scroll to its footer on a phone viewport', () => {
+		cy.authenticate('/patients/search');
+
+		cy.get('.searchPatient').should(($el) => {
+			expect($el.css('position')).to.equal('relative');
+		});
+		cy.window().then((win) => {
+			win.scrollTo(0, win.document.documentElement.scrollHeight);
+		});
+		cy.get('.searchPatient .footer').should('be.visible');
+	});
+});

--- a/cypress/integrations/mobile_usability.cy.ts
+++ b/cypress/integrations/mobile_usability.cy.ts
@@ -12,7 +12,9 @@ describe('Mobile usability spec', () => {
 		cy.dataCy('app-header').should('have.class', 'open_menu');
 		cy.get('body').should('have.class', 'disable-scroll');
 
-		cy.get('.appHeader__nav__item').contains(/patients/i).click();
+		cy.get('.appHeader__nav__item')
+			.contains(/patients/i)
+			.click();
 
 		cy.url().should('include', '/patients');
 		cy.dataCy('app-header').should('not.have.class', 'open_menu');
@@ -27,7 +29,9 @@ describe('Mobile usability spec', () => {
 		cy.get('body').should('have.class', 'disable-scroll');
 
 		// same-route navigation: the pathname does not change, the menu must close anyway
-		cy.get('.appHeader__nav__item').contains(/patients/i).click();
+		cy.get('.appHeader__nav__item')
+			.contains(/patients/i)
+			.click();
 
 		cy.url().should('include', '/patients');
 		cy.dataCy('app-header').should('not.have.class', 'open_menu');

--- a/src/components/accessories/appHeader/AppHeader.tsx
+++ b/src/components/accessories/appHeader/AppHeader.tsx
@@ -4,7 +4,12 @@ import NavigateBefore from '@mui/icons-material/NavigateBefore';
 import { Tooltip, Typography } from '@mui/material';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import classNames from 'classnames';
-import { type FunctionComponent, useCallback, useEffect, useState } from 'react';
+import {
+	type FunctionComponent,
+	useCallback,
+	useEffect,
+	useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';

--- a/src/components/accessories/appHeader/AppHeader.tsx
+++ b/src/components/accessories/appHeader/AppHeader.tsx
@@ -4,9 +4,9 @@ import NavigateBefore from '@mui/icons-material/NavigateBefore';
 import { Tooltip, Typography } from '@mui/material';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import classNames from 'classnames';
-import { type FunctionComponent, useEffect, useState } from 'react';
+import { type FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import logo from '../../../assets/logo-color.svg';
@@ -40,12 +40,10 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 	const hospital = useAppSelector(
 		(state) => state.hospital.getHospital.data,
 	) as HospitalDTO;
-	const openMenu = (isOpen: boolean) => {
-		isOpen
-			? document.body.classList.add('disable-scroll')
-			: document.body.classList.remove('disable-scroll');
-		setIsOpen(isOpen);
-	};
+	const openMenu = useCallback((open: boolean) => {
+		document.body.classList.toggle('disable-scroll', open);
+		setIsOpen(open);
+	}, []);
 	const [openLogoutConfirmation, setOpenLogoutConfirmation] = useState(false);
 	const showHelp = useShowHelp();
 	const handleLogout = () => {
@@ -53,6 +51,14 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 		dispatch(setLogout());
 	};
 	const navigate = useNavigate();
+
+	// OH2-475: close the mobile menu (and restore body scrolling) on every route change, so tapping a
+	// nav item — or the logo/breadcrumb links — does not leave the overlay open with the body scroll-locked
+	const { pathname } = useLocation();
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the intended trigger — the effect must re-run on navigation
+	useEffect(() => {
+		openMenu(false);
+	}, [pathname]);
 
 	const canAccessPatient = usePermission('patients.access');
 	const canAccessVisit = usePermission('opds.access');

--- a/src/components/accessories/appHeader/AppHeader.tsx
+++ b/src/components/accessories/appHeader/AppHeader.tsx
@@ -60,6 +60,13 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 		openMenu(false);
 	}, [pathname]);
 
+	// OH2-475: nav items close the menu explicitly too — navigating to the current route
+	// does not change the pathname, so the effect above would not fire
+	const navigateFromMenu = (path: string) => {
+		openMenu(false);
+		navigate(path);
+	};
+
 	const canAccessPatient = usePermission('patients.access');
 	const canAccessVisit = usePermission('opds.access');
 	const canAccessLaboratory = usePermission('laboratories.access');
@@ -142,7 +149,7 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 							{canAccessDashboard && (
 								<div
 									className="appHeader__nav__item"
-									onClick={() => navigate(PATHS.dashboard)}
+									onClick={() => navigateFromMenu(PATHS.dashboard)}
 								>
 									{t('nav.dashboard')}
 								</div>
@@ -150,7 +157,7 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 							{canAccessAdmin && (
 								<div
 									className="appHeader__nav__item"
-									onClick={() => navigate(PATHS.admin)}
+									onClick={() => navigateFromMenu(PATHS.admin)}
 								>
 									{t('nav.administration')}
 								</div>
@@ -158,7 +165,7 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 							{canAccessPatient && (
 								<div
 									className="appHeader__nav__item"
-									onClick={() => navigate(PATHS.patients)}
+									onClick={() => navigateFromMenu(PATHS.patients)}
 								>
 									{t('nav.patients')}
 								</div>
@@ -166,7 +173,7 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 							{canAccessVisit && (
 								<div
 									className="appHeader__nav__item"
-									onClick={() => navigate(PATHS.visits)}
+									onClick={() => navigateFromMenu(PATHS.visits)}
 								>
 									{t('nav.visits')}
 								</div>
@@ -174,7 +181,7 @@ const AppHeader: FunctionComponent<IOwnProps> = ({ breadcrumbMap }) => {
 							{canAccessLaboratory && (
 								<div
 									className="appHeader__nav__item"
-									onClick={() => navigate(PATHS.laboratory)}
+									onClick={() => navigateFromMenu(PATHS.laboratory)}
 								>
 									{t('nav.laboratory')}
 								</div>

--- a/src/components/accessories/checkboxField/styles.scss
+++ b/src/components/accessories/checkboxField/styles.scss
@@ -3,6 +3,7 @@
 .dateField {
   //height: 60px;
   width: 250px;
+  max-width: 100%;
   label {
     top: 5px;
     &.MuiFormLabel-filled,

--- a/src/components/accessories/customModal/styles.scss
+++ b/src/components/accessories/customModal/styles.scss
@@ -1,23 +1,12 @@
 @import "../../../styles/variables";
-@import "../../../../node_modules/susy/sass/susy";
 
 .custom__modal {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 800px;
-  @include susy-media($narrow) {
-    width: 800px;
-  }
-  @include susy-media($tablet_land) {
-    width: 600px;
-  }
-  @include susy-media($tablet_port) {
-    width: 400px;
-  }
-  @include susy-media($smartphone) {
-    width: 300px;
-  }
+  // OH2-475: responsive width — up to 800px on wide screens, but never wider than the viewport (minus a
+  // small margin), so the modal fits on phones and tablets instead of using fixed per-breakpoint widths
+  width: min(800px, 100vw - 2rem);
 
   .MuiCardContent-root {
     padding: 10px;

--- a/src/components/accessories/dashboard/dashboardContent/filter/styles.scss
+++ b/src/components/accessories/dashboard/dashboardContent/filter/styles.scss
@@ -29,6 +29,14 @@
           padding: 0px 0px 0px 10px;
         }
       }
+      // OH2-475: keep the period picker inside phone viewports instead of overflowing horizontally
+      @include susy-media($smartphone) {
+        flex-wrap: wrap;
+        max-width: 100%;
+        button {
+          padding: 5px 9px;
+        }
+      }
     }
   }
   .filter__actions {

--- a/src/components/accessories/dashboard/layouts/breakpoints.test.ts
+++ b/src/components/accessories/dashboard/layouts/breakpoints.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getBreakpointFromWidth } from './breakpoints';
+
+describe('getBreakpointFromWidth', () => {
+	it('maps desktop and tablet widths to their breakpoints', () => {
+		expect(getBreakpointFromWidth(1440)).toBe('lg');
+		expect(getBreakpointFromWidth(1280)).toBe('lg');
+		expect(getBreakpointFromWidth(1000)).toBe('md');
+		expect(getBreakpointFromWidth(800)).toBe('sm');
+		expect(getBreakpointFromWidth(500)).toBe('xs');
+	});
+
+	it('maps phone widths below the xs breakpoint to xxs (OH2-475: no longer falls back to md)', () => {
+		expect(getBreakpointFromWidth(489)).toBe('xxs');
+		expect(getBreakpointFromWidth(390)).toBe('xxs');
+		expect(getBreakpointFromWidth(0)).toBe('xxs');
+	});
+});

--- a/src/components/accessories/dashboard/layouts/breakpoints.ts
+++ b/src/components/accessories/dashboard/layouts/breakpoints.ts
@@ -1,0 +1,49 @@
+/**
+ * Dashboard responsive breakpoints and column configuration for react-grid-layout.
+ *
+ * Kept in its own module, free of any browser/session-storage dependency, so the breakpoint mapping can be
+ * unit-tested in isolation.
+ */
+
+export const defaultGridLayoutCols: { [key: string]: number } = {
+	lg: 12,
+	md: 12,
+	sm: 12,
+	xs: 12,
+	xxs: 12,
+};
+
+export const defaultGridLayoutBreakpoints = {
+	lg: 1280,
+	md: 992,
+	sm: 760,
+	xs: 490,
+	xxs: 0,
+};
+
+/**
+ * Determine breakpoint to apply based on display size
+ * @param width number
+ * @returns The breakpoint to be applied
+ */
+export const getBreakpointFromWidth = (width: number): string => {
+	if (width >= defaultGridLayoutBreakpoints.lg) {
+		return 'lg';
+	}
+
+	if (width >= defaultGridLayoutBreakpoints.md) {
+		return 'md';
+	}
+
+	if (width >= defaultGridLayoutBreakpoints.sm) {
+		return 'sm';
+	}
+
+	if (width >= defaultGridLayoutBreakpoints.xs) {
+		return 'xs';
+	}
+
+	// OH2-475: below the xs breakpoint (phone widths) use the xxs layout, which stacks the widgets
+	// full-width, instead of falling back to md and squeezing them into half-width columns
+	return 'xxs';
+};

--- a/src/components/accessories/dashboard/layouts/consts.ts
+++ b/src/components/accessories/dashboard/layouts/consts.ts
@@ -51,46 +51,11 @@ export const defaultLayoutConfig: Layouts = {
 	xxs: generateLayout('xxs'),
 };
 
-export const defaultGridLayoutCols: { [key: string]: number } = {
-	lg: 12,
-	md: 12,
-	sm: 12,
-	xs: 12,
-	xxs: 12,
-};
-
-export const defaultGridLayoutBreakpoints = {
-	lg: 1280,
-	md: 992,
-	sm: 760,
-	xs: 490,
-	xxs: 0,
-};
-
-/**
- * Determine breakpoint to apply based on display size
- * @param width number
- * @returns The breakpoint to be applied
- */
-export const getBreakpointFromWidth = (width: number): string => {
-	if (width >= defaultGridLayoutBreakpoints.lg) {
-		return 'lg';
-	}
-
-	if (width >= defaultGridLayoutBreakpoints.md) {
-		return 'md';
-	}
-
-	if (width >= defaultGridLayoutBreakpoints.sm) {
-		return 'sm';
-	}
-
-	if (width >= defaultGridLayoutBreakpoints.xs) {
-		return 'xs';
-	}
-
-	return 'md';
-};
+export {
+	defaultGridLayoutBreakpoints,
+	defaultGridLayoutCols,
+	getBreakpointFromWidth,
+} from './breakpoints';
 
 /**
  * Get dashboard label's translation key

--- a/src/components/accessories/dashboard/layouts/container/GridLayoutContainer.tsx
+++ b/src/components/accessories/dashboard/layouts/container/GridLayoutContainer.tsx
@@ -44,7 +44,13 @@ const GridLayoutContainer: FC = () => {
 
 	const [mounted, setMounted] = useState(false);
 	const [canUpdateLayouts, setCanUpdateLayouts] = useState(true);
-	const [localBreakpoint, setLocalBreakpoint] = useState<string>('md');
+	// starting at 'md' would let the first frame render as a desktop layout, so on a phone
+	// dragging and resizing flash on before the first breakpoint change turns them off
+	const [localBreakpoint, setLocalBreakpoint] = useState<string>(() =>
+		typeof window !== 'undefined'
+			? getBreakpointFromWidth(window.innerWidth)
+			: 'md',
+	);
 	const [fsDashboard, setFsDashboard] = useState<
 		TDashboardComponent | undefined
 	>(undefined);

--- a/src/components/accessories/dashboard/layouts/container/GridLayoutContainer.tsx
+++ b/src/components/accessories/dashboard/layouts/container/GridLayoutContainer.tsx
@@ -192,6 +192,10 @@ const GridLayoutContainer: FC = () => {
 		t(state.layouts.saveLayouts.error?.message || 'dashboard.cantsaveconfig'),
 	);
 
+	// OH2-475: on phone widths the widgets stack full-width; disable drag/resize/drop there, since those
+	// interactions are awkward on touch and would only let the user break the single-column mobile layout
+	const isTouchLayout = localBreakpoint === 'xxs';
+
 	return (
 		<div ref={gridLayoutRef}>
 			{(getLayoutsStatus === 'LOADING' || resetLayoutsStatus === 'LOADING') && (
@@ -254,9 +258,9 @@ const GridLayoutContainer: FC = () => {
 								layouts={layouts}
 								onBreakpointChange={onBreakpointChange}
 								onLayoutChange={onLayoutChange}
-								isDraggable
-								isDroppable
-								isResizable
+								isDraggable={!isTouchLayout}
+								isDroppable={!isTouchLayout}
+								isResizable={!isTouchLayout}
 								measureBeforeMount={false}
 								useCSSTransforms={mounted}
 								draggableHandle=".DashboardCard-item-header"

--- a/src/components/accessories/largeButton/styles.scss
+++ b/src/components/accessories/largeButton/styles.scss
@@ -6,6 +6,7 @@
   position: relative;
   height: 140px;
   width: 300px;
+  max-width: 100%;
   border-radius: 10px !important;
 
   .largeButton__inner {

--- a/src/components/accessories/smallButton/styles.scss
+++ b/src/components/accessories/smallButton/styles.scss
@@ -5,4 +5,5 @@
   color: $c-white !important;
   height: 40px;
   width: 120px;
+  max-width: 100%;
 }

--- a/src/components/accessories/textButton/styles.scss
+++ b/src/components/accessories/textButton/styles.scss
@@ -4,4 +4,5 @@
   color: $c-color-primary !important;
   height: 40px;
   width: 120px;
+  max-width: 100%;
 }

--- a/src/components/accessories/textField/styles.scss
+++ b/src/components/accessories/textField/styles.scss
@@ -3,6 +3,7 @@
 .textField {
   //height: 60px;
   width: 250px;
+  max-width: 100%;
   label {
     top: 5px;
     // font-size: smaller;

--- a/src/components/activities/PermissionDenied/PermissionDenied.module.scss
+++ b/src/components/activities/PermissionDenied/PermissionDenied.module.scss
@@ -24,11 +24,11 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: calc(100vh - 120px);
+  min-height: calc(100vh - 120px);
   width: 100vw;
   background-color: $c-color-secondary;
   @include susy-media($smartphone) {
     padding: 50px 0 100px 0;
-    height: 100%;
+    min-height: 100%;
   }
 }

--- a/src/components/activities/dashboardActivity/styles.scss
+++ b/src/components/activities/dashboardActivity/styles.scss
@@ -5,9 +5,9 @@
   display: flex;
   flex-direction: column;
   margin: 0px;
-  height: calc(100vh - 120px);
+  min-height: calc(100vh - 120px);
   @include susy-media($smartphone){
-    height: 100%;
+    min-height: 100%;
   }
   .dashboard__background {
     flex: 1;

--- a/src/components/activities/forgotActivity/styles.scss
+++ b/src/components/activities/forgotActivity/styles.scss
@@ -7,12 +7,12 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    height: calc(100vh - 120px);
+    min-height: calc(100vh - 120px);
     width: 100vw;
     background-color: $c-color-secondary;
     @include susy-media($smartphone) {
       padding: 50px 0 100px 0;
-      height: 100%;
+      min-height: 100%;
     }
   }
 

--- a/src/components/activities/loginActivity/styles.scss
+++ b/src/components/activities/loginActivity/styles.scss
@@ -7,12 +7,12 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    height: calc(100vh - 120px);
+    min-height: calc(100vh - 120px);
     width: 100vw;
     background-color: $c-color-secondary;
     @include susy-media($smartphone) {
       padding: 50px 0 100px 0;
-      height: 100%;
+      min-height: 100%;
     }
   }
 

--- a/src/components/activities/searchPatientActivity/styles.scss
+++ b/src/components/activities/searchPatientActivity/styles.scss
@@ -5,8 +5,10 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  position: absolute;
-  height: 100%;
+  // OH2-475: use natural flow instead of position:absolute + height:100% (which took the container
+  // out of flow, collapsed the parent and could leave overflowing content unreachable on mobile)
+  position: relative;
+  min-height: 100vh;
   width: 100%;
   background-color: $c-color-secondary;
 


### PR DESCRIPTION
## OH2-475 — mobile usability

### Navigation (mobile header menu)
- The mobile menu now closes and restores body scrolling on **every route change** (nav items and the logo/breadcrumb links), via a `useLocation` effect.
- Tapping the nav item of the **current route** also closes the menu — same-route navigation does not change the pathname, so the menu is closed explicitly (`navigateFromMenu`).
- `openMenu` toggles the `disable-scroll` body class cleanly, so the scroll lock is never left orphaned.

### Scroll / layout
- Full-viewport activity containers use `min-height` instead of a fixed `height: calc(100vh - …)`, so pages scroll naturally on phone viewports.
- The patient-search container is taken out of `position: absolute` (now `position: relative` + `min-height`) so it can scroll to its footer.
- The dashboard period picker wraps within phone widths instead of overflowing.

### Dashboard (phone breakpoint)
- `getBreakpointFromWidth` fell back to `md` below the `xs` breakpoint, so phone widths rendered the two-column `md` layout and squeezed the widgets to half-width. Sub-`xs` widths now map to `xxs` (full-width, stacked), and drag/resize/drop are disabled on that breakpoint (awkward on touch).
- The breakpoint helper and its config were extracted into a window-free module and covered by a unit test.

### Shared modal
- The shared `CustomModal` used fixed per-breakpoint widths (800/600/400/300px). Replaced with a single responsive rule — up to 800px, capped to the viewport minus a margin — so it fits on any width and uses the available space on phones.

### Tests
- `cypress/integrations/mobile_usability.cy.ts`: 5 specs at a 390×844 viewport (menu-close-on-navigation via nav item / current route / logo link, dashboard document flow, patient-search scroll). All green (run with the `--lang=en-US` electron flag).
- `breakpoints.test.ts`: unit test for the phone-breakpoint mapping.

Remaining for a follow-up: responsive max-width rules on the other shared fixed-width fields/buttons/panels (a live overflow audit across pages).