### PR TITLE
OH2-469 Fix the discard prompt after creating a user + untranslated OK button

### DIFF
--- a/src/components/accessories/admin/users/newUser/NewUser.tsx
+++ b/src/components/accessories/admin/users/newUser/NewUser.tsx
@@ -75,7 +75,8 @@ export const NewUser = () => {
 	}, [dispatch]);
 
 	useEffect(() => {
-		if (create.hasSucceeded) navigate(PATHS.admin_users);
+		// OH2-469: navigate with replace so the unsaved-changes blocker does not prompt to discard after a successful create
+		if (create.hasSucceeded) navigate(PATHS.admin_users, { replace: true });
 		return () => {
 			dispatch(createUserReset());
 		};
@@ -217,7 +218,7 @@ export const NewUser = () => {
 						title={t('user.createdSuccessTitle')}
 						icon={checkIcon}
 						info={t('user.createdSuccessMessage')}
-						primaryButtonLabel="Ok"
+						primaryButtonLabel={t('common.ok')}
 						handlePrimaryButtonClick={() => {
 							navigate(PATHS.admin_users, { replace: true });
 						}}
@@ -228,7 +229,7 @@ export const NewUser = () => {
 						title={t('errors.internalerror')}
 						icon={warningIcon}
 						info={create.error?.message.toString()}
-						primaryButtonLabel="Ok"
+						primaryButtonLabel={t('common.ok')}
 						handlePrimaryButtonClick={() => {
 							dispatch(createUserReset(), { replace: true });
 						}}


### PR DESCRIPTION
## OH2-469

### Route blocker
After a successful user creation, `NewUser` navigated to the users list with a plain (push) navigation, so the unsaved-changes route blocker (`useBlocker` in `useDiscardHelpers`) intercepted it and prompted *"discard changes?"* even though the user had just been saved. Navigate with `{ replace: true }` — which the blocker ignores (it only blocks non-`REPLACE` actions), and which the success dialog's own OK handler already uses.

### Translation
The success and error confirmation dialogs had a hardcoded `primaryButtonLabel="Ok"`. Replaced with `t('common.ok')`, matching how the rest of the app labels that button.

### Verification
`tsc --noEmit` clean and `vite build` green.