### PR TITLE
OH2-478 Fix horizontal overflow on core-workflow pages using the grid container

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -7,6 +7,15 @@
   box-sizing: border-box;
 }
 
+// OH2-478: flexboxgrid pins .container to a fixed width at each breakpoint
+// (e.g. 49rem at min-width 48em), which is wider than the viewport itself in
+// the 768-783px range and causes horizontal overflow on tablet-portrait. Clamp
+// the grid container so the core-workflow pages that use it never overflow on
+// mobile/tablet. Harmless on desktop, where the fixed widths stay below 100%.
+.container {
+  max-width: 100%;
+}
+
 .App {
   & > div {
     min-height: 100vh;


### PR DESCRIPTION
## OH2-478 — Core Workflow Mobile Fixes

Sub-task of the mobile usability story (OH2-475).

### Root cause
`flexboxgrid` pins `.container` to a **fixed width at each breakpoint** (`49rem` at `min-width: 48em`, `65rem` at `64em`, `76rem` at `75em`). At the lower edge of a breakpoint that fixed width is *wider than the viewport itself* — e.g. `49rem` (784px) at a 768px viewport — so every page that uses `.container` overflows horizontally on **tablet-portrait**, and the login container overflowed on **small phones** too.

Only `patientDetailsActivity` worked around it, with a per-view `.container { width: 100% }` override. Search Patient (and any other `.container` page) had no such guard.

### Fix
Clamp the grid container once, in the global stylesheet:
```scss
.container { max-width: 100%; }
```
It never exceeds the viewport on mobile/tablet, and is a no-op on desktop where the fixed widths already stay below 100%.

### Verification
Ran the mobile baseline audit (from OH2-480) locally at **phone-small (360)**, **phone-modern (390)**, **fairphone-4 (411)** and **tablet-portrait (768)**.

| Route | before | after |
|---|---|---|
| patient-search | ✗ overflow @768 | ✓ all viewports |
| patient-details | ✓ | ✓ |
| visits | ✓ | ✓ |
| laboratory | ✓ | ✓ |
| login (bonus) | ✗ overflow @360/411 | ✓ |

The only remaining audit failures are the *"closes the mobile menu after navigation"* checks, which depend on the AppHeader route-change behaviour delivered by OH2-476 (#787) and are out of scope here.

`tsc --noEmit` clean and `vite build` green.