### PR TITLE
OH2-479 Collapse the admin section menu after navigating on mobile

### DIFF
--- a/src/components/activities/adminActivity/AdminActivity.tsx
+++ b/src/components/activities/adminActivity/AdminActivity.tsx
@@ -1,7 +1,7 @@
 import { useMediaQuery } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet } from 'react-router';
+import { Outlet, useLocation } from 'react-router';
 import { PATHS } from '../../../consts';
 import { useAppSelector } from '../../../libraries/hooks/redux';
 import { scrollToElement } from '../../../libraries/uiUtils/scrollToElement';
@@ -20,6 +20,7 @@ const AdminActivity = () => {
 	const [expanded, setExpanded] = useState(false);
 	const { t } = useTranslation();
 	const matches = useMediaQuery('(min-width:768px)');
+	const location = useLocation();
 
 	const breadcrumbMap = {
 		[t('nav.administration')]: PATHS.admin,
@@ -32,6 +33,13 @@ const AdminActivity = () => {
 	useEffect(() => {
 		scrollToElement(null);
 	}, []);
+
+	// OH2-479: on mobile the admin section menu is a collapsible accordion.
+	// Collapse it after navigating to a section so the selected content is
+	// immediately visible instead of being pushed below the still-open menu.
+	useEffect(() => {
+		setExpanded(false);
+	}, [location.pathname]);
 
 	return (
 		<div data-cy="admin-activity" className={classes.admin}>


### PR DESCRIPTION
## OH2-479 — Admin Area Mobile Fixes and Regression QA

Sub-task of the mobile usability story (OH2-475).

### Problem
On mobile the admin area renders its section navigation as a collapsible **"Menu"** accordion. Selecting a section navigated to it but left the accordion **expanded**, so the chosen content (e.g. the Diseases table) was pushed far below the still-open menu — the user had to scroll past the whole menu or close it by hand to see what they had selected.

### Fix
Collapse the accordion on route change in `AdminActivity`, mirroring the AppHeader mobile-menu behaviour:
```tsx
useEffect(() => {
  setExpanded(false);
}, [location.pathname]);
```
The selected content is now immediately visible; the menu still opens and toggles normally, and on desktop (where the menu is always shown, not an accordion) this is a no-op.

### Regression QA
Ran the mobile baseline audit (OH2-480) plus targeted per-page probes at **phone-small (360)**, **phone-modern (390)**, **fairphone-4 (411)** and **tablet-portrait (768)**:

- `/admin` passes the audit at all four viewports.
- Every admin **list** page (users, wards, diseases, operations, …) and **new/edit form** has **zero horizontal page overflow** — wide tables scroll inside their `TableContainer` rather than pushing the page.
- The side menu opens, and now collapses after a section is chosen.

The only remaining audit failures are unrelated to the admin area and belong to sibling sub-tasks: the grid-container overflow on login/patient-search (OH2-478, #791) and the "close menu after navigation" AppHeader check (OH2-476, #787).

`tsc --noEmit` clean and `vite build` green.