### PR TITLE
OH2-488 OH2-489 Fix laboratory date input validation

### DIFF
--- a/src/components/accessories/dateField/DateField.tsx
+++ b/src/components/accessories/dateField/DateField.tsx
@@ -8,6 +8,7 @@ import type { IProps } from './types';
 const DateField: FunctionComponent<IProps> = ({
 	fieldName,
 	fieldValue,
+	preserveDraftInput = false,
 	disableFuture,
 	disabled,
 	label,
@@ -25,6 +26,7 @@ const DateField: FunctionComponent<IProps> = ({
 	const [value, setValue] = useState<Date | null>(null);
 	const [anchorEl, setAnchorEl] = useState(null);
 	const anchorElRef = useRef(null);
+	const skipNextExternalSync = useRef(false);
 	const matches = useMediaQuery('(min-width:768px)');
 
 	useEffect(() => {
@@ -32,13 +34,29 @@ const DateField: FunctionComponent<IProps> = ({
 	}, []);
 
 	useEffect(() => {
+		if (preserveDraftInput && skipNextExternalSync.current) {
+			skipNextExternalSync.current = false;
+			return;
+		}
+
 		// field value comes in timestamp string (eg. 2020-03-19T14:58:00.000Z)
-		fieldValue === '' ? setValue(null) : setValue(new Date(fieldValue));
-	}, [fieldValue]);
+		if (fieldValue === '') {
+			setValue(null);
+			return;
+		}
+
+		const externalValue = new Date(fieldValue);
+		if (!Number.isNaN(externalValue.getTime())) {
+			setValue(externalValue);
+		}
+	}, [fieldValue, preserveDraftInput]);
 
 	const handleDateChange = (date: Date | null) => {
-		onChange(date);
+		// MUI fields keep an internal draft while the user edits date sections.
+		// Do not feed the same intermediate value back through the external prop.
+		skipNextExternalSync.current = preserveDraftInput;
 		setValue(date);
+		onChange(date);
 	};
 
 	const actualClassName = theme === 'light' ? 'dateField__light' : 'dateField';

--- a/src/components/accessories/dateField/types.ts
+++ b/src/components/accessories/dateField/types.ts
@@ -7,6 +7,7 @@ import type { FIELD_VALIDATION } from '../../../types';
 export interface IProps {
 	fieldName: string;
 	fieldValue: string;
+	preserveDraftInput?: boolean;
 	disableFuture?: boolean;
 	disabled?: boolean;
 	theme?: 'light' | 'regular';

--- a/src/components/accessories/laboratory/consts.ts
+++ b/src/components/accessories/laboratory/consts.ts
@@ -1,24 +1,27 @@
 import moment from 'moment';
-import {
-	fixFilterDateFrom,
-	fixFilterDateTo,
-} from '../../../libraries/formDataHandling/functions';
 import type { TFields } from '../../../libraries/formDataHandling/types';
 import type { ExamFormFieldName } from './examForm/type';
 import type { ExamRequestFormFieldName } from './examRequestForm/types';
+import {
+	formatLocalFilterDateFrom,
+	formatLocalFilterDateTo,
+} from './filter/dateUtils';
 import type { ExamFilterFormFieldName, TFilterValues } from './filter/types';
 
 export const initialFilterFields: TFields<ExamFilterFormFieldName> = {
-	dateFrom: { type: 'date', value: moment().startOf('month').toISOString() },
-	dateTo: { type: 'date', value: moment().toISOString() },
+	dateFrom: {
+		type: 'date',
+		value: moment().subtract(1, 'day').format('YYYY-MM-DD'),
+	},
+	dateTo: { type: 'date', value: moment().format('YYYY-MM-DD') },
 	examName: { type: 'text', value: '' },
 	patientCode: { type: 'number', value: '' },
 	status: { type: 'text', value: '' },
 };
 
 export const initialFilter: TFilterValues = {
-	dateFrom: fixFilterDateFrom(moment().subtract(1, 'years').toISOString()),
-	dateTo: fixFilterDateTo(moment().toISOString()),
+	dateFrom: formatLocalFilterDateFrom(moment().subtract(1, 'day').toDate()),
+	dateTo: formatLocalFilterDateTo(moment().toDate()),
 	status: '',
 	page: 0,
 	size: 80,

--- a/src/components/accessories/laboratory/filter/ExamFilterForm.tsx
+++ b/src/components/accessories/laboratory/filter/ExamFilterForm.tsx
@@ -160,14 +160,30 @@ export const ExamFilterForm: FC<IExamFilterProps> = ({
 	});
 
 	const dateFieldHandleOnChange = useCallback(
-		(fieldName: string) => (val: Date | null) => {
-			setFieldValue(fieldName, val);
+		(fieldName: string) => async (val: Date | null) => {
 			if (fieldName === 'dateFrom' || fieldName === 'dateTo') {
-				setFieldValue('month', '');
-				setFieldValue('year', '');
-				formik.setFieldTouched('dateTo');
-				formik.setFieldTouched('dateFrom');
+				const isCompleteDate =
+					val instanceof Date && !Number.isNaN(val.getTime());
+				const nextValues = {
+					...formik.values,
+					[fieldName]: val,
+					month: '',
+					year: '',
+				};
+
+				await formik.setValues(nextValues, isCompleteDate);
+				await formik.setTouched(
+					{
+						...formik.touched,
+						dateTo: isCompleteDate,
+						dateFrom: isCompleteDate,
+					},
+					false,
+				);
+				return;
 			}
+
+			setFieldValue(fieldName, val);
 
 			if (fieldName === 'month') {
 				const month = val?.getUTCMonth() ?? new Date().getUTCMonth();
@@ -267,6 +283,7 @@ export const ExamFilterForm: FC<IExamFilterProps> = ({
 										theme={'regular'}
 										fieldName="dateFrom"
 										fieldValue={removeTime(formik.values.dateFrom)}
+										preserveDraftInput={true}
 										disableFuture={true}
 										format="dd/MM/yyyy"
 										isValid={isValid('dateFrom')}
@@ -279,6 +296,7 @@ export const ExamFilterForm: FC<IExamFilterProps> = ({
 									<DateField
 										fieldName="dateTo"
 										fieldValue={removeTime(formik.values.dateTo)}
+										preserveDraftInput={true}
 										disableFuture={true}
 										theme="regular"
 										format="dd/MM/yyyy"

--- a/src/components/accessories/laboratory/filter/ExamFilterForm.tsx
+++ b/src/components/accessories/laboratory/filter/ExamFilterForm.tsx
@@ -21,8 +21,6 @@ import {
 	type PatientDTO,
 } from '../../../../generated';
 import {
-	fixFilterDateFrom,
-	fixFilterDateTo,
 	formatAllFieldValues,
 	getFromFields,
 	removeTime,
@@ -34,6 +32,11 @@ import ConfirmationDialog from '../../confirmationDialog/ConfirmationDialog';
 import DateField from '../../dateField/DateField';
 import PatientPicker from '../../patientPicker/PatientPicker';
 import SelectField from '../../selectField/SelectField';
+import {
+	formatLocalFilterDateFrom,
+	formatLocalFilterDateTo,
+	isFutureLocalDate,
+} from './dateUtils';
 import './styles.scss';
 import type { IExamFilterProps, TFilterValues } from './types';
 
@@ -74,7 +77,7 @@ export const ExamFilterForm: FC<IExamFilterProps> = ({
 				message: t('lab.futuredatenotallow'),
 				test: (value) => {
 					if (!moment(value).isValid()) return true;
-					return differenceInSeconds(new Date(value), new Date()) <= 0;
+					return !isFutureLocalDate(value);
 				},
 			}),
 		dateTo: string()
@@ -102,7 +105,7 @@ export const ExamFilterForm: FC<IExamFilterProps> = ({
 				message: t('lab.futuredatenotallow'),
 				test: (value) => {
 					if (!moment(value).isValid()) return true;
-					return differenceInSeconds(new Date(value), new Date()) <= 0;
+					return !isFutureLocalDate(value);
 				},
 			}),
 		status: string(),
@@ -122,11 +125,11 @@ export const ExamFilterForm: FC<IExamFilterProps> = ({
 			) as TFilterValues;
 
 			if (formattedValues.dateFrom) {
-				formattedValues.dateFrom = fixFilterDateFrom(formattedValues.dateFrom);
+				formattedValues.dateFrom = formatLocalFilterDateFrom(values.dateFrom);
 			}
 
 			if (formattedValues.dateTo) {
-				formattedValues.dateTo = fixFilterDateTo(formattedValues.dateTo);
+				formattedValues.dateTo = formatLocalFilterDateTo(values.dateTo);
 			}
 
 			onSubmit(formattedValues);

--- a/src/components/accessories/laboratory/filter/dateUtils.test.ts
+++ b/src/components/accessories/laboratory/filter/dateUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+	formatLocalFilterDateFrom,
+	formatLocalFilterDateTo,
+	isFutureLocalDate,
+} from './dateUtils';
+
+describe('laboratory filter date utilities', () => {
+	it('keeps the locally selected calendar day in the API range', () => {
+		const selectedDate = new Date(2026, 7, 28);
+
+		expect(formatLocalFilterDateFrom(selectedDate)).toBe(
+			'2026-08-28T00:00:00.000Z',
+		);
+		expect(formatLocalFilterDateTo(selectedDate)).toBe(
+			'2026-08-28T23:59:59.999Z',
+		);
+	});
+
+	it('does not consider today future just after local midnight', () => {
+		const now = new Date(2026, 7, 28, 0, 12);
+		const today = new Date(2026, 7, 28);
+
+		expect(isFutureLocalDate(today, now)).toBe(false);
+	});
+
+	it('still rejects the following local calendar day', () => {
+		const now = new Date(2026, 7, 28, 23, 59);
+		const tomorrow = new Date(2026, 7, 29);
+
+		expect(isFutureLocalDate(tomorrow, now)).toBe(true);
+	});
+});

--- a/src/components/accessories/laboratory/filter/dateUtils.ts
+++ b/src/components/accessories/laboratory/filter/dateUtils.ts
@@ -1,0 +1,14 @@
+import moment from 'moment';
+
+const API_DATE_TIME_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]';
+
+export const isFutureLocalDate = (
+	value: string | Date,
+	now: Date = new Date(),
+): boolean => moment(value).startOf('day').isAfter(moment(now).startOf('day'));
+
+export const formatLocalFilterDateFrom = (value: string | Date): string =>
+	moment(value).startOf('day').format(API_DATE_TIME_FORMAT);
+
+export const formatLocalFilterDateTo = (value: string | Date): string =>
+	moment(value).endOf('day').format(API_DATE_TIME_FORMAT);

--- a/src/libraries/formDataHandling/functions.test.ts
+++ b/src/libraries/formDataHandling/functions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { removeTime } from './functions';
+
+describe('removeTime', () => {
+	it('returns an invalid date without throwing', () => {
+		expect(() => removeTime(new Date(Number.NaN))).not.toThrow();
+		expect(removeTime(new Date(Number.NaN))).toBe('Invalid Date');
+	});
+
+	it('handles a cleared or dropped field value', () => {
+		expect(removeTime(null)).toBe('');
+		expect(removeTime(undefined)).toBe('');
+	});
+
+	it('removes the time without mutating the provided date', () => {
+		const date = new Date('2026-08-27T14:30:45.000Z');
+		const expectedLocalDate = [
+			date.getFullYear(),
+			`${date.getMonth() + 1}`.padStart(2, '0'),
+			`${date.getDate()}`.padStart(2, '0'),
+		].join('-');
+
+		expect(removeTime(date)).toBe(expectedLocalDate);
+		expect(date.toISOString()).toBe('2026-08-27T14:30:45.000Z');
+	});
+
+	it('keeps the calendar day selected at local midnight', () => {
+		const date = new Date(2026, 7, 28);
+
+		expect(removeTime(date)).toBe('2026-08-28');
+	});
+
+	it('removes the time from an ISO date string', () => {
+		const date = new Date('2026-08-27T14:30:45.000Z');
+		const expectedLocalDate = [
+			date.getFullYear(),
+			`${date.getMonth() + 1}`.padStart(2, '0'),
+			`${date.getDate()}`.padStart(2, '0'),
+		].join('-');
+
+		expect(removeTime('2026-08-27T14:30:45.000Z')).toBe(expectedLocalDate);
+	});
+});

--- a/src/libraries/formDataHandling/functions.ts
+++ b/src/libraries/formDataHandling/functions.ts
@@ -72,16 +72,18 @@ export const fixFilterDateFrom = (date: string | Date): string => {
 	return date.toISOString();
 };
 
-export const removeTime = (date: string | Date): string => {
-	if (date instanceof Date) {
-		date.setUTCHours(0);
-		date.setUTCMinutes(0);
-		date.setUTCSeconds(0);
+export const removeTime = (date: string | Date | null | undefined): string => {
+	if (date == null) return '';
 
-		date = date.toISOString();
-	}
+	if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) return date;
 
-	return date.split('T')[0];
+	const parsedDate = date instanceof Date ? date : new Date(date);
+	if (Number.isNaN(parsedDate.getTime())) return parsedDate.toString();
+
+	const year = parsedDate.getFullYear();
+	const month = `${parsedDate.getMonth() + 1}`.padStart(2, '0');
+	const day = `${parsedDate.getDate()}`.padStart(2, '0');
+	return `${year}-${month}-${day}`;
 };
 
 export const fixFilterDateTo = (date: string | Date): string => {


### PR DESCRIPTION
See OH2-488 OH2-489.

Fixes date handling in the Laboratory filter:
- preserves partially typed dates without resetting or shifting the selected day;
- prevents malformed or intermediate values from crashing date conversion;
- uses local calendar dates instead of UTC conversion;
- updates date values and related Formik state atomically;
- prevents stale cross-field validation errors between Date From and Date To;
- keeps the draft-input behavior scoped to the Laboratory date range fields;
- changes the default Laboratory date range to yesterday–today to avoid retrieving unnecessary historical records.