### PR TITLE
chore: bump volta.node pin to 22.23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
 		"vitest": "^4.1.10"
 	},
 	"volta": {
-		"node": "20.18.1"
+		"node": "22.23.2"
 	},
 	"msw": {
 		"workerDirectory": [


### PR DESCRIPTION
@almeida1492 
As agreed, this bumps the pin to `22.23.2` (current Node 22 LTS) to match. Done!