### PR TITLE
OP-1037 Show the administrative flag in the patient dashboard

### DIFF
--- a/api/oh.yaml
+++ b/api/oh.yaml
@@ -6451,6 +6451,14 @@ components:
           type: boolean
           description: Consensus service flag
           example: true
+        consensusAdministrativeFlag:
+          type: boolean
+          description: Consensus administrative flag
+          example: true
+        consensusAdministrativeReason:
+          type: string
+          description: Reason why the administration flagged the patient
+          maxLength: 255
       required:
       - age
       - bloodType
@@ -6855,6 +6863,13 @@ components:
         serviceFlag:
           type: boolean
           description: Service flag
+        administrativeFlag:
+          type: boolean
+          description: Administrative flag
+        administrativeReason:
+          type: string
+          description: Reason why the administration flagged the patient
+          maxLength: 255
         patientId:
           type: integer
           format: int32

--- a/cypress/integrations/patient_details_activity/administrative_flag.cy.ts
+++ b/cypress/integrations/patient_details_activity/administrative_flag.cy.ts
@@ -1,0 +1,16 @@
+/// <reference types="cypress" />
+
+describe('Patient Details / Administrative flag', () => {
+	before(() => {
+		cy.authenticate('/patients/details/1');
+	});
+
+	it('should warn that the patient has an administrative issue', () => {
+		cy.dataCy('patient-details');
+		cy.contains('Administrative issue');
+	});
+
+	it('should show the reason the administration gave', () => {
+		cy.contains('Insurance to be verified');
+	});
+});

--- a/cypress/integrations/patient_details_activity/administrative_flag.cy.ts
+++ b/cypress/integrations/patient_details_activity/administrative_flag.cy.ts
@@ -11,6 +11,6 @@ describe('Patient Details / Administrative flag', () => {
 	});
 
 	it('should show the reason the administration gave', () => {
-		cy.contains('Insurance to be verified');
+		cy.contains('Insurance still needs to be verified');
 	});
 });

--- a/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
+++ b/src/components/activities/patientDetailsActivity/PatientDetailsActivity.tsx
@@ -23,6 +23,7 @@ import {
 	AccordionDetails,
 	AccordionSummary,
 } from '../../accessories/accordion/Accordion';
+import { AlertBox } from '../../accessories/alertBox/AlertBox';
 import AppHeader from '../../accessories/appHeader/AppHeader';
 import Button from '../../accessories/button/Button';
 import Footer from '../../accessories/footer/Footer';
@@ -240,6 +241,19 @@ const PatientDetailsActivity = () => {
 												</div>
 											</div>
 										</div>
+
+										{patient.data?.consensusAdministrativeFlag && (
+											<div className="patientDetails__administrativeFlag">
+												<AlertBox
+													type="warning"
+													title={t('patient.administrativeflag')}
+													message={
+														patient.data?.consensusAdministrativeReason ||
+														t('patient.administrativeflagmessage')
+													}
+												/>
+											</div>
+										)}
 
 										<Permission require="patients.update">
 											<div className="patientDetails__personalData_edit_button_wrapper">

--- a/src/components/activities/patientDetailsActivity/styles.scss
+++ b/src/components/activities/patientDetailsActivity/styles.scss
@@ -258,6 +258,25 @@
     }
   }
 
+  .patientDetails__administrativeFlag {
+    margin: 20px;
+
+    // AlertBox is laid out for the wide content area: in this narrow column its gaps
+    // push the icon away from the text and wrap the title
+    > div {
+      column-gap: 12px;
+      padding: 12px;
+      margin: 0;
+    }
+    > div > div:first-child {
+      padding: 0;
+      align-items: flex-start;
+    }
+    // the default caption colour is meant for the light background
+    > div > div:nth-child(2) {
+      color: $c-white;
+    }
+  }
   .patientDetails_status {
     margin: 20px;
     .patientDetails_status_wrapper {

--- a/src/mocks/fixtures/patientDTO.ts
+++ b/src/mocks/fixtures/patientDTO.ts
@@ -12,7 +12,7 @@ import {
 export const patientDTO: PatientDTO = {
 	code: 1,
 	consensusAdministrativeFlag: true,
-	consensusAdministrativeReason: 'Insurance to be verified',
+	consensusAdministrativeReason: 'Insurance still needs to be verified',
 	status: PatientDTOStatusEnum.I,
 	firstName: 'Antonio Carlos',
 	secondName: 'Jobim',

--- a/src/mocks/fixtures/patientDTO.ts
+++ b/src/mocks/fixtures/patientDTO.ts
@@ -11,6 +11,8 @@ import {
 
 export const patientDTO: PatientDTO = {
 	code: 1,
+	consensusAdministrativeFlag: true,
+	consensusAdministrativeReason: 'Insurance to be verified',
 	status: PatientDTOStatusEnum.I,
 	firstName: 'Antonio Carlos',
 	secondName: 'Jobim',

--- a/src/resources/i18n/en.json
+++ b/src/resources/i18n/en.json
@@ -166,6 +166,8 @@
 		"emptylayout": "No displayed widget. Start by adding widgets"
 	},
 	"patient": {
+		"administrativeflag": "Administrative issue",
+		"administrativeflagmessage": "This patient has an administrative issue to be solved. Please check with the administration before providing further services.",
 		"address": "Address",
 		"birthdate": "Birth Date",
 		"bloodtype": "Blood type",

--- a/src/resources/i18n/it.json
+++ b/src/resources/i18n/it.json
@@ -153,6 +153,8 @@
 		"emptylayout": "Nessun widget visualizzato. Inizia aggiungendo widget."
 	},
 	"patient": {
+		"administrativeflag": "Questione amministrativa",
+		"administrativeflagmessage": "Questo paziente ha una questione amministrativa da risolvere. Verificare con l'amministrazione prima di erogare altri servizi.",
 		"address": "Indirizzo",
 		"birthdate": "Data di nascita",
 		"bloodtype": "Gruppo Sanguigno",


### PR DESCRIPTION
Web UI side of [OP-1037](https://openhospital.atlassian.net/browse/OP-1037). The administrative flag marks a patient whose administrative position has to be solved before they are served again — missing paperwork, an unpaid bill, an insurance still to be verified. @mwithi asked for a warning that signals the issue without ever blocking care, and for an optional free-text reason to go with it.

## What this does

The patient sidebar in the dashboard shows a warning whenever the selected patient carries the flag, with the reason the administration gave (or a generic message when no reason was written). Nothing is blocked and no permission is involved: it is a signal for whoever is about to start a service.

It reuses the existing `AlertBox` (`type="warning"`) rather than adding a new component. That component is laid out for the wide content area, so in the narrow sidebar its gaps pushed the icon away from the text and wrapped the title; the three style rules in `styles.scss` tighten it for this one instance and fix the caption colour, which is meant for the light background.

## Notes for review

* `api/oh.yaml` is aligned with informatici/openhospital-api#592 (two optional properties). The generated client is not committed, so it comes from `npm run codegen`.
* Strings added in `en` and `it`.
* On a phone the patient column is collapsible, so the warning is visible once that panel is open. Happy to lift it above the panel if you would rather have it always visible.
* Verified at desktop width and at 390×844. New cypress spec `patient_details_activity/administrative_flag.cy.ts` covers the banner and its reason; the existing patient specs still pass with the flagged fixture.

Depends on core informatici/openhospital-core#1620 and api informatici/openhospital-api#592. The Swing GUI side is informatici/openhospital-gui#2222 and the manual is informatici/openhospital-doc#296.

Where this belongs is still open: I asked @mwithi on the ticket whether he wanted it here or folded into one of the UI branches already in review — happy to move it.

[OP-1037]: https://openhospital.atlassian.net/browse/OP-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
