### PR TITLE
OP-884 Limit the web UI form fields to the length the API accepts

### DIFF
--- a/cypress/integrations/admin_activities/types_activities/diseases_activities/add_disease_activity.cy.ts
+++ b/cypress/integrations/admin_activities/types_activities/diseases_activities/add_disease_activity.cy.ts
@@ -14,7 +14,7 @@ describe('Add disease type Activity specs', () => {
 	});
 
 	it('should fail to create a new disease type', () => {
-		cy.byId('code').type('FAIL');
+		cy.byId('code').type('FA');
 		cy.byId('description').type('Disease type');
 		cy.dataCy('submit-form').click();
 		cy.dataCy('info-box').contains('Fail');

--- a/cypress/integrations/admin_activities/types_activities/medicals_activities/add_medical_activity.cy.ts
+++ b/cypress/integrations/admin_activities/types_activities/medicals_activities/add_medical_activity.cy.ts
@@ -21,7 +21,7 @@ describe('Add medical type Activity specs', () => {
 	});
 
 	it('should successfully create a new medical type', () => {
-		cy.byId('code').clear().type('22');
+		cy.byId('code').clear().type('2');
 		cy.dataCy('submit-form').click();
 		cy.dataCy('dialog-info').contains(
 			'The medical type has been created successfully!',

--- a/cypress/integrations/admin_activities/types_activities/medicals_activities/add_medical_activity.cy.ts
+++ b/cypress/integrations/admin_activities/types_activities/medicals_activities/add_medical_activity.cy.ts
@@ -14,7 +14,7 @@ describe('Add medical type Activity specs', () => {
 	});
 
 	it('should fail to create a new medical type', () => {
-		cy.byId('code').type('FAIL');
+		cy.byId('code').type('F');
 		cy.byId('description').type('Medical type');
 		cy.dataCy('submit-form').click();
 		cy.dataCy('info-box').contains('Fail');

--- a/cypress/integrations/admin_activities/types_activities/operations_activities/add_operation_activity.cy.ts
+++ b/cypress/integrations/admin_activities/types_activities/operations_activities/add_operation_activity.cy.ts
@@ -14,7 +14,7 @@ describe('Add operation type Activity specs', () => {
 	});
 
 	it('should fail to create a new operation type', () => {
-		cy.byId('code').type('FAIL');
+		cy.byId('code').type('FA');
 		cy.byId('description').type('Operation type');
 		cy.dataCy('submit-form').click();
 		cy.dataCy('info-box').contains('Fail');

--- a/cypress/integrations/admin_activities/types_activities/vaccines_activities/add_vaccine_activity.cy.ts
+++ b/cypress/integrations/admin_activities/types_activities/vaccines_activities/add_vaccine_activity.cy.ts
@@ -14,7 +14,7 @@ describe('Add vaccine type Activity specs', () => {
 	});
 
 	it('should fail to create a new vaccine type', () => {
-		cy.byId('code').type('FAIL');
+		cy.byId('code').type('F');
 		cy.byId('description').type('Vaccine type');
 		cy.dataCy('submit-form').click();
 		cy.dataCy('info-box').contains('Fail');

--- a/cypress/integrations/field_length_limits.cy.ts
+++ b/cypress/integrations/field_length_limits.cy.ts
@@ -7,8 +7,8 @@ const PATIENT_START_PATH = '/patients/new';
 const SUPPLIER_START_PATH = '/admin/suppliers/new';
 const MEDICAL_TYPE_START_PATH = '/admin/types/medicals';
 const USER_START_PATH = '/admin/users/new';
-const HOSPITAL_START_PATH = '/admin/hospital/edit';
-const PATIENT_DETAILS_START_PATH = '/patients/details/1234563';
+const ADMIN_START_PATH = '/admin';
+const TRIAGE_START_PATH = '/patients/details/1234563/triage';
 
 const expectLimit = (fieldId: string, limit: number) => {
 	cy.byId(fieldId).should('have.attr', 'maxlength', `${limit}`);
@@ -18,7 +18,7 @@ describe('Field length limits specs', () => {
 	describe('Ward form', () => {
 		it('should render the ui', () => {
 			cy.authenticate(WARD_START_PATH);
-			cy.dataCy('activity-title').contains('Add Ward');
+			cy.byId('code').should('exist');
 		});
 
 		it('should limit every field to the length the API accepts', () => {
@@ -91,7 +91,7 @@ describe('Field length limits specs', () => {
 		it('should render the ui', () => {
 			cy.authenticate(MEDICAL_TYPE_START_PATH);
 			cy.dataCy('add-medical-type').click();
-			cy.dataCy('sub-medical-title').contains('New medical type');
+			cy.byId('code').should('exist');
 		});
 
 		it('should keep the single character the code column holds', () => {
@@ -104,7 +104,7 @@ describe('Field length limits specs', () => {
 	describe('User form', () => {
 		it('should render the ui', () => {
 			cy.authenticate(USER_START_PATH);
-			cy.dataCy('activity-title').contains('New user');
+			cy.byId('userName').should('exist');
 		});
 
 		it('should limit the user name and the description', () => {
@@ -123,15 +123,16 @@ describe('Field length limits specs', () => {
 
 	describe('Hospital form', () => {
 		it('should limit the currency code', () => {
-			cy.authenticate(HOSPITAL_START_PATH);
+			cy.authenticate(ADMIN_START_PATH);
+			cy.dataCy('hospital-infos').click();
+			cy.dataCy('edit-hospital').click();
 			expectLimit('currencyCod', FIELD_LENGTHS.HospitalDTO.currencyCod);
 		});
 	});
 
 	describe('Triage form', () => {
 		it('should limit the note to what the examination accepts', () => {
-			cy.authenticate(PATIENT_DETAILS_START_PATH);
-			cy.dataCy('patient-details-main-menu').contains('Triage').click();
+			cy.authenticate(TRIAGE_START_PATH);
 			expectLimit('pex_note', FIELD_LENGTHS.PatientExaminationDTO.pex_note);
 		});
 	});

--- a/cypress/integrations/field_length_limits.cy.ts
+++ b/cypress/integrations/field_length_limits.cy.ts
@@ -8,6 +8,10 @@ const SUPPLIER_START_PATH = '/admin/suppliers/new';
 const MEDICAL_TYPE_START_PATH = '/admin/types/medicals';
 const USER_START_PATH = '/admin/users/new';
 const ADMIN_START_PATH = '/admin';
+const VACCINE_TYPE_START_PATH = '/admin/types/vaccines';
+const DISEASE_TYPE_START_PATH = '/admin/types/diseases';
+const OPERATION_TYPE_START_PATH = '/admin/types/operations';
+const GROUP_WITHOUT_DESCRIPTION_PATH = '/admin/users/groups/edit/doc';
 const TRIAGE_START_PATH = '/patients/details/1234563/triage';
 
 const expectLimit = (fieldId: string, limit: number) => {
@@ -134,6 +138,45 @@ describe('Field length limits specs', () => {
 		it('should limit the note to what the examination accepts', () => {
 			cy.authenticate(TRIAGE_START_PATH);
 			expectLimit('pex_note', FIELD_LENGTHS.PatientExaminationDTO.pex_note);
+		});
+	});
+	describe('Type forms whose code column holds one or two characters', () => {
+		it('should limit the vaccine type code', () => {
+			cy.authenticate(VACCINE_TYPE_START_PATH);
+			cy.dataCy('add-vaccine-type').click();
+			expectLimit('code', FIELD_LENGTHS.VaccineTypeDTO.code);
+		});
+
+		it('should limit the disease type code', () => {
+			cy.authenticate(DISEASE_TYPE_START_PATH);
+			cy.dataCy('add-disease-type').click();
+			expectLimit('code', FIELD_LENGTHS.DiseaseTypeDTO.code);
+		});
+
+		it('should limit the operation type code', () => {
+			cy.authenticate(OPERATION_TYPE_START_PATH);
+			cy.dataCy('add-operation-type').click();
+			expectLimit('code', FIELD_LENGTHS.OperationTypeDTO.code);
+		});
+	});
+
+	describe('Remaining characters badge', () => {
+		it('should stay on the field that already showed it', () => {
+			cy.authenticate(SUPPLIER_START_PATH);
+			cy.get('[data-cy=remaining-chars]').should('have.length', 1);
+		});
+
+		it('should not follow a field that only gained a limit', () => {
+			cy.authenticate(WARD_START_PATH);
+			cy.byId('code').should('exist');
+			cy.get('[data-cy=remaining-chars]').should('not.exist');
+		});
+	});
+
+	describe('Group without a description', () => {
+		it('should render the form when the description the contract makes optional is absent', () => {
+			cy.authenticate(GROUP_WITHOUT_DESCRIPTION_PATH);
+			cy.byId('desc').should('exist');
 		});
 	});
 });

--- a/cypress/integrations/field_length_limits.cy.ts
+++ b/cypress/integrations/field_length_limits.cy.ts
@@ -1,0 +1,57 @@
+/// <reference types="cypress" />
+
+import { FIELD_LENGTHS } from '../../src/consts';
+
+const WARD_START_PATH = '/admin/wards/new';
+const PATIENT_START_PATH = '/patients/new';
+
+const expectLimit = (fieldId: string, limit: number) => {
+	cy.byId(fieldId).should('have.attr', 'maxlength', `${limit}`);
+};
+
+describe('Field length limits specs', () => {
+	describe('Ward form', () => {
+		it('should render the ui', () => {
+			cy.authenticate(WARD_START_PATH);
+			cy.dataCy('activity-title').contains('Add Ward');
+		});
+
+		it('should limit every field to the length the API accepts', () => {
+			expectLimit('code', FIELD_LENGTHS.WardDTO.code);
+			expectLimit('description', FIELD_LENGTHS.WardDTO.description);
+			expectLimit('telephone', FIELD_LENGTHS.WardDTO.telephone);
+			expectLimit('fax', FIELD_LENGTHS.WardDTO.fax);
+			expectLimit('email', FIELD_LENGTHS.WardDTO.email);
+		});
+
+		it('should keep only the characters that fit the limit', () => {
+			cy.byId('code').clear().type('ABCDEFGHIJ', { delay: 0 });
+			cy.byId('code').should('have.value', 'ABC');
+		});
+	});
+
+	describe('Patient form', () => {
+		it('should render the ui', () => {
+			cy.authenticate(PATIENT_START_PATH);
+			cy.dataCy('patient-data-form');
+		});
+
+		it('should limit every field to the length the API accepts', () => {
+			expectLimit('firstName', FIELD_LENGTHS.PatientDTO.firstName);
+			expectLimit('secondName', FIELD_LENGTHS.PatientDTO.secondName);
+			expectLimit('taxCode', FIELD_LENGTHS.PatientDTO.taxCode);
+			expectLimit('address', FIELD_LENGTHS.PatientDTO.address);
+			expectLimit('telephone', FIELD_LENGTHS.PatientDTO.telephone);
+			expectLimit('note', FIELD_LENGTHS.PatientDTO.note);
+		});
+
+		it('should keep only the characters that fit the limit', () => {
+			const overLimit = 'a'.repeat(FIELD_LENGTHS.PatientDTO.taxCode + 10);
+			cy.byId('taxCode').clear().type(overLimit, { delay: 0 });
+			cy.byId('taxCode').should(
+				'have.value',
+				'a'.repeat(FIELD_LENGTHS.PatientDTO.taxCode),
+			);
+		});
+	});
+});

--- a/cypress/integrations/field_length_limits.cy.ts
+++ b/cypress/integrations/field_length_limits.cy.ts
@@ -46,6 +46,7 @@ describe('Field length limits specs', () => {
 			expectLimit('secondName', FIELD_LENGTHS.PatientDTO.secondName);
 			expectLimit('taxCode', FIELD_LENGTHS.PatientDTO.taxCode);
 			expectLimit('address', FIELD_LENGTHS.PatientDTO.address);
+			expectLimit('city', FIELD_LENGTHS.PatientDTO.city);
 			expectLimit('telephone', FIELD_LENGTHS.PatientDTO.telephone);
 			expectLimit('note', FIELD_LENGTHS.PatientDTO.note);
 		});

--- a/cypress/integrations/field_length_limits.cy.ts
+++ b/cypress/integrations/field_length_limits.cy.ts
@@ -4,6 +4,11 @@ import { FIELD_LENGTHS } from '../../src/consts';
 
 const WARD_START_PATH = '/admin/wards/new';
 const PATIENT_START_PATH = '/patients/new';
+const SUPPLIER_START_PATH = '/admin/suppliers/new';
+const MEDICAL_TYPE_START_PATH = '/admin/types/medicals';
+const USER_START_PATH = '/admin/users/new';
+const HOSPITAL_START_PATH = '/admin/hospital/edit';
+const PATIENT_DETAILS_START_PATH = '/patients/details/1234563';
 
 const expectLimit = (fieldId: string, limit: number) => {
 	cy.byId(fieldId).should('have.attr', 'maxlength', `${limit}`);
@@ -52,6 +57,81 @@ describe('Field length limits specs', () => {
 				'have.value',
 				'a'.repeat(FIELD_LENGTHS.PatientDTO.taxCode),
 			);
+		});
+	});
+
+	describe('Supplier form', () => {
+		it('should render the ui', () => {
+			cy.authenticate(SUPPLIER_START_PATH);
+			cy.byId('supName').type('ACME Pharma');
+		});
+
+		it('should limit every field to the length the API accepts', () => {
+			expectLimit('supName', FIELD_LENGTHS.SupplierDTO.supName);
+			expectLimit('supAddress', FIELD_LENGTHS.SupplierDTO.supAddress);
+			expectLimit('supTaxcode', FIELD_LENGTHS.SupplierDTO.supTaxcode);
+			expectLimit('supPhone', FIELD_LENGTHS.SupplierDTO.supPhone);
+			expectLimit('supFax', FIELD_LENGTHS.SupplierDTO.supFax);
+			expectLimit('supEmail', FIELD_LENGTHS.SupplierDTO.supEmail);
+			expectLimit('supNote', FIELD_LENGTHS.SupplierDTO.supNote);
+		});
+
+		it('should keep only the characters that fit the limit', () => {
+			cy.byId('supNote').type(
+				'n'.repeat(FIELD_LENGTHS.SupplierDTO.supNote + 40),
+			);
+			cy.byId('supNote')
+				.invoke('val')
+				.should('have.length', FIELD_LENGTHS.SupplierDTO.supNote);
+		});
+	});
+
+	describe('Medical type form', () => {
+		it('should render the ui', () => {
+			cy.authenticate(MEDICAL_TYPE_START_PATH);
+			cy.dataCy('add-medical-type').click();
+			cy.dataCy('sub-medical-title').contains('New medical type');
+		});
+
+		it('should keep the single character the code column holds', () => {
+			expectLimit('code', FIELD_LENGTHS.MedicalTypeDTO.code);
+			cy.byId('code').type('ABC', { delay: 0 });
+			cy.byId('code').should('have.value', 'A');
+		});
+	});
+
+	describe('User form', () => {
+		it('should render the ui', () => {
+			cy.authenticate(USER_START_PATH);
+			cy.dataCy('activity-title').contains('New user');
+		});
+
+		it('should limit the user name and the description', () => {
+			expectLimit('desc', FIELD_LENGTHS.UserDTO.desc);
+			cy.byId('userName').type(
+				'u'.repeat(FIELD_LENGTHS.UserDTO.userName + 10),
+				{
+					delay: 0,
+				},
+			);
+			cy.byId('userName')
+				.invoke('val')
+				.should('have.length', FIELD_LENGTHS.UserDTO.userName);
+		});
+	});
+
+	describe('Hospital form', () => {
+		it('should limit the currency code', () => {
+			cy.authenticate(HOSPITAL_START_PATH);
+			expectLimit('currencyCod', FIELD_LENGTHS.HospitalDTO.currencyCod);
+		});
+	});
+
+	describe('Triage form', () => {
+		it('should limit the note to what the examination accepts', () => {
+			cy.authenticate(PATIENT_DETAILS_START_PATH);
+			cy.dataCy('patient-details-main-menu').contains('Triage').click();
+			expectLimit('pex_note', FIELD_LENGTHS.PatientExaminationDTO.pex_note);
 		});
 	});
 });

--- a/cypress/interceptors/diseaseTypes.ts
+++ b/cypress/interceptors/diseaseTypes.ts
@@ -5,14 +5,14 @@ export const diseaseTypes = [
 	http.get('/diseasetypes', () => jsonResponse(diseaseTypesDTO)),
 	http.post('/diseasetypes', (req) => {
 		const body = req.body;
-		if (body.code === 'FAIL') {
+		if (body.code === 'FA') {
 			return badRequest({ message: 'Fail to create disease type' });
 		}
 		return jsonResponse(body, 201);
 	}),
 	http.put('/diseasetypes', (req) => {
 		const body = req.body;
-		if (body.code === 'FAIL') {
+		if (body.code === 'FA') {
 			return badRequest({ message: 'Fail to update disease type' });
 		}
 		return jsonResponse(body);
@@ -20,7 +20,7 @@ export const diseaseTypes = [
 	http.delete('/diseasetypes/{code}', (req) => {
 		const url = new URL(req.url);
 		const code = url.pathname.split('/').pop();
-		if (code === 'FAIL') {
+		if (code === 'FA') {
 			return badRequest({ message: 'Fail to delete disease type' });
 		}
 		return jsonResponse(true);

--- a/src/components/accessories/admin/diseases/diseaseForm/DiseaseForm.tsx
+++ b/src/components/accessories/admin/diseases/diseaseForm/DiseaseForm.tsx
@@ -9,7 +9,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -154,6 +154,7 @@ const DiseaseForm: FC<IDiseaseProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.DiseaseDTO.code}
 						/>
 					</div>
 					<div className="diseaseForm__item">
@@ -179,6 +180,7 @@ const DiseaseForm: FC<IDiseaseProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.DiseaseDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/exams/examForm/ExamForm.tsx
+++ b/src/components/accessories/admin/exams/examForm/ExamForm.tsx
@@ -18,7 +18,7 @@ import { array, number, object, string } from 'yup';
 import DiscardButton from '~/components/accessories/discardButton/DiscardButton';
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -246,6 +246,7 @@ const ExamForm: FC<IExamProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.ExamDTO.code}
 						/>
 					</div>
 					<div className="examForm__item halfWidth">
@@ -258,6 +259,7 @@ const ExamForm: FC<IExamProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.ExamDTO.description}
 						/>
 					</div>
 				</div>
@@ -287,6 +289,7 @@ const ExamForm: FC<IExamProps> = ({
 								onBlur={formik.handleBlur}
 								type="text"
 								disabled={isLoading || formik.values.procedure === '1'}
+								maxLength={FIELD_LENGTHS.ExamDTO.defaultResult}
 							/>
 						</div>
 					)}

--- a/src/components/accessories/admin/hospital/hospitalForm/HospitalForm.tsx
+++ b/src/components/accessories/admin/hospital/hospitalForm/HospitalForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -98,6 +98,7 @@ const HospitalForm: FC<IHospitalFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.HospitalDTO.description}
 						/>
 					</div>
 					<div className="hospitalForm__item halfWidth">
@@ -110,6 +111,7 @@ const HospitalForm: FC<IHospitalFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.HospitalDTO.address}
 						/>
 					</div>
 					<div className="hospitalForm__item halfWidth">
@@ -122,6 +124,7 @@ const HospitalForm: FC<IHospitalFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.HospitalDTO.city}
 						/>
 					</div>
 
@@ -135,6 +138,7 @@ const HospitalForm: FC<IHospitalFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.HospitalDTO.telephone}
 						/>
 					</div>
 					<div className="hospitalForm__item halfWidth">
@@ -147,6 +151,7 @@ const HospitalForm: FC<IHospitalFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.HospitalDTO.fax}
 						/>
 					</div>
 					<div className="hospitalForm__item halfWidth">
@@ -159,6 +164,7 @@ const HospitalForm: FC<IHospitalFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="email"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.HospitalDTO.email}
 						/>
 					</div>
 					<div className="hospitalForm__item halfWidth">
@@ -171,6 +177,7 @@ const HospitalForm: FC<IHospitalFormProps> = ({
 							errorText={getErrorText('currencyCod')}
 							onBlur={formik.handleBlur}
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.HospitalDTO.currencyCod}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/operations/operationForm/OperationForm.tsx
+++ b/src/components/accessories/admin/operations/operationForm/OperationForm.tsx
@@ -10,7 +10,7 @@ import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { OperationDTOOpeForEnum } from '~/generated/models/OperationDTO';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -163,6 +163,7 @@ const OperationForm: FC<IOperationProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.OperationDTO.code}
 						/>
 					</div>
 					<div className="operationForm__item halfWidth">
@@ -191,6 +192,7 @@ const OperationForm: FC<IOperationProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.OperationDTO.description}
 						/>
 					</div>
 					<div className="operationForm__item thirdWidth">

--- a/src/components/accessories/admin/suppliers/supplierForm/SupplierForm.tsx
+++ b/src/components/accessories/admin/suppliers/supplierForm/SupplierForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -135,6 +135,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.SupplierDTO.supName}
 						/>
 					</div>
 					<div className="supplierForm__item halfWidth">
@@ -147,6 +148,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.SupplierDTO.supAddress}
 						/>
 					</div>
 					<div className="supplierForm__item halfWidth">
@@ -159,6 +161,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.SupplierDTO.supTaxcode}
 						/>
 					</div>
 
@@ -172,6 +175,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.SupplierDTO.supPhone}
 						/>
 					</div>
 					<div className="supplierForm__item halfWidth">
@@ -184,6 +188,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.SupplierDTO.supFax}
 						/>
 					</div>
 					<div className="supplierForm__item halfWidth">
@@ -196,6 +201,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="email"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.SupplierDTO.supEmail}
 						/>
 					</div>
 				</div>
@@ -213,7 +219,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							onBlur={formik.handleBlur}
 							rows={3}
 							disabled={isLoading}
-							maxLength={1500}
+							maxLength={FIELD_LENGTHS.SupplierDTO.supNote}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/suppliers/supplierForm/SupplierForm.tsx
+++ b/src/components/accessories/admin/suppliers/supplierForm/SupplierForm.tsx
@@ -220,6 +220,7 @@ const SupplierForm: FC<ISupplierFormProps> = ({
 							rows={3}
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.SupplierDTO.supNote}
+							showRemaining
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/admissions/admissionTypesForm/AdmissionTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/admissions/admissionTypesForm/AdmissionTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -123,6 +123,7 @@ const AdmissionTypeForm: FC<IAdmissionTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.AdmissionTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/deliveries/deliveryTypesForm/DeliveryTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/deliveries/deliveryTypesForm/DeliveryTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -123,6 +123,7 @@ const DeliveryTypeForm: FC<IDeliveryTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.DeliveryTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/deliveryresulttypes/deliveryResultTypeForm/DeliveryResultTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/deliveryresulttypes/deliveryResultTypeForm/DeliveryResultTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -128,6 +128,7 @@ const DeliveryResultTypeForm: FC<IDeliveryResultTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.DeliveryResultTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/discharges/dischargeTypesForm/DischargeTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/discharges/dischargeTypesForm/DischargeTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -123,6 +123,7 @@ const DischargeTypeForm: FC<IDischargeTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.DischargeTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/diseases/diseaseTypesForm/DiseaseTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/diseases/diseaseTypesForm/DiseaseTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -111,6 +111,7 @@ const DiseaseTypeForm: FC<IDiseaseTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.DiseaseTypeDTO.code}
 						/>
 					</div>
 					<div className="diseaseTypesForm__item halfWidth">
@@ -123,6 +124,7 @@ const DiseaseTypeForm: FC<IDiseaseTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.DiseaseTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/exams/examTypesForm/ExamTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/exams/examTypesForm/ExamTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -122,6 +122,7 @@ const ExamTypeForm: FC<IExamTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.ExamTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/medicals/medicalTypesForm/MedicalTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/medicals/medicalTypesForm/MedicalTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -111,6 +111,7 @@ const MedicalTypeForm: FC<IMedicalTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.MedicalTypeDTO.code}
 						/>
 					</div>
 					<div className="medicalTypesForm__item halfWidth">
@@ -123,6 +124,7 @@ const MedicalTypeForm: FC<IMedicalTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.MedicalTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/operations/operationTypesForm/OperationTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/operations/operationTypesForm/OperationTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -111,6 +111,7 @@ const OperationTypeForm: FC<IOperationTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.OperationTypeDTO.code}
 						/>
 					</div>
 					<div className="operationTypesForm__item halfWidth">
@@ -123,6 +124,7 @@ const OperationTypeForm: FC<IOperationTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.OperationTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/pregnanttreatmenttypes/pregnantTreatmentTypeForm/PregnantTreatmentTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/pregnanttreatmenttypes/pregnantTreatmentTypeForm/PregnantTreatmentTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -116,6 +116,7 @@ const PregnantTreatmentTypeForm: FC<IPregnantTreatmentTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.PregnantTreatmentTypeDTO.code}
 						/>
 					</div>
 					<div className="pregnantTreatmentTypesForm__item halfWidth">
@@ -128,6 +129,7 @@ const PregnantTreatmentTypeForm: FC<IPregnantTreatmentTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.PregnantTreatmentTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/types/components/vaccines/vaccineTypesForm/VaccineTypeForm.tsx
+++ b/src/components/accessories/admin/types/components/vaccines/vaccineTypesForm/VaccineTypeForm.tsx
@@ -8,7 +8,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -111,6 +111,7 @@ const VaccineTypeForm: FC<IVaccineTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.VaccineTypeDTO.code}
 						/>
 					</div>
 					<div className="vaccineTypesForm__item halfWidth">
@@ -123,6 +124,7 @@ const VaccineTypeForm: FC<IVaccineTypeFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.VaccineTypeDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/users/editGroup/EditGroup.tsx
+++ b/src/components/accessories/admin/users/editGroup/EditGroup.tsx
@@ -12,7 +12,7 @@ import type { PermissionDTO } from '~/generated/models/PermissionDTO';
 import type { UserGroupDTO } from '~/generated/models/UserGroupDTO';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import { usePermission } from '../../../../../libraries/permissionUtils/usePermission';
 import { getAllPermissions } from '../../../../../state/permissions';
 import {
@@ -179,6 +179,7 @@ export const EditGroup = () => {
 									onBlur={handleBlur}
 									type="text"
 									disabled
+									maxLength={FIELD_LENGTHS.UserGroupDTO.code}
 								/>
 							</div>
 							<div className="editGroupForm__item fullWidth">
@@ -189,6 +190,7 @@ export const EditGroup = () => {
 									isValid={!!touched.desc && !!errors.desc}
 									errorText={(touched.desc && errors.desc) || ''}
 									onBlur={handleBlur}
+									maxLength={FIELD_LENGTHS.UserGroupDTO.desc}
 								/>
 							</div>
 						</div>

--- a/src/components/accessories/admin/users/editUser/EditUserForm.tsx
+++ b/src/components/accessories/admin/users/editUser/EditUserForm.tsx
@@ -12,7 +12,7 @@ import CheckboxField from '~/components/accessories/checkboxField/CheckboxField'
 import DiscardButton from '~/components/accessories/discardButton/DiscardButton';
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import type { UserDTO, UserGroupDTO } from '../../../../../generated';
 import Button from '../../../button/Button';
 import ConfirmationDialog from '../../../confirmationDialog/ConfirmationDialog';
@@ -138,6 +138,7 @@ export const EditUserForm = ({
 							type="password"
 							// this below prevents from saving the password on the computer
 							InputProps={{ autoComplete: 'one-time-code' }}
+							maxLength={FIELD_LENGTHS.UserDTO.passwd}
 						/>
 					</div>
 					<div className="editUserForm__item halfWidth">
@@ -151,6 +152,7 @@ export const EditUserForm = ({
 							type="password"
 							// this below prevents from saving the password on the computer
 							InputProps={{ autoComplete: 'one-time-code' }}
+							maxLength={FIELD_LENGTHS.UserDTO.passwd}
 						/>
 					</div>
 					<div className="editUserForm__item fullWidth">
@@ -163,6 +165,7 @@ export const EditUserForm = ({
 							isValid={!!touched.desc && !!errors.desc}
 							errorText={(touched.desc && errors.desc) || ''}
 							onBlur={handleBlur}
+							maxLength={FIELD_LENGTHS.UserDTO.desc}
 						/>
 					</div>
 					<div className="editUserForm__item fullWidth">

--- a/src/components/accessories/admin/users/newGroup/NewGroup.tsx
+++ b/src/components/accessories/admin/users/newGroup/NewGroup.tsx
@@ -8,7 +8,7 @@ import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { AdminActivityContent } from '~/components/activities/adminActivity';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import type { UserGroupDTO } from '../../../../../generated';
 import {
 	createUserGroup,
@@ -86,6 +86,7 @@ export const NewGroup = () => {
 								errorText={(touched.code && errors.code) || ''}
 								onBlur={handleBlur}
 								type="text"
+								maxLength={FIELD_LENGTHS.UserGroupDTO.code}
 							/>
 						</div>
 						<div className="newGroupForm__item fullWidth">
@@ -96,6 +97,7 @@ export const NewGroup = () => {
 								isValid={!!touched.desc && !!errors.desc}
 								errorText={(touched.desc && errors.desc) || ''}
 								onBlur={handleBlur}
+								maxLength={FIELD_LENGTHS.UserGroupDTO.desc}
 							/>
 						</div>
 						<div className="newGroupForm__item fullWidth">

--- a/src/components/accessories/admin/users/newUser/NewUser.tsx
+++ b/src/components/accessories/admin/users/newUser/NewUser.tsx
@@ -18,7 +18,7 @@ import type { UserGroupDTO } from '~/generated/models/UserGroupDTO';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
 import warningIcon from '../../../../../assets/warning-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import { getUserGroups } from '../../../../../state/usergroups';
 import { createUser, createUserReset } from '../../../../../state/users';
 import type { IState } from '../../../../../types';
@@ -106,6 +106,7 @@ export const NewUser = () => {
 								errorText={(touched.userName && errors.userName) || ''}
 								onBlur={handleBlur}
 								type="text"
+								maxLength={FIELD_LENGTHS.UserDTO.userName}
 							/>
 						</div>
 						<div className="newUserForm__item halfWidth">
@@ -119,6 +120,7 @@ export const NewUser = () => {
 								type="password"
 								// this below prevents from saving the password on the computer
 								InputProps={{ autoComplete: 'one-time-code' }}
+								maxLength={FIELD_LENGTHS.UserDTO.passwd}
 							/>
 						</div>
 						<div className="newUserForm__item halfWidth">
@@ -132,6 +134,7 @@ export const NewUser = () => {
 								type="password"
 								// this below prevents from saving the password on the computer
 								InputProps={{ autoComplete: 'one-time-code' }}
+								maxLength={FIELD_LENGTHS.UserDTO.passwd}
 							/>
 						</div>
 						<hr />
@@ -186,6 +189,7 @@ export const NewUser = () => {
 								onBlur={handleBlur}
 								rows={3}
 								multiline
+								maxLength={FIELD_LENGTHS.UserDTO.desc}
 							/>
 						</div>
 						<div className="newUserForm__item fullWidth">

--- a/src/components/accessories/admin/users/newUser/validation.ts
+++ b/src/components/accessories/admin/users/newUser/validation.ts
@@ -1,4 +1,5 @@
 import { boolean, object, ref, string } from 'yup';
+import { FIELD_LENGTHS } from '~/consts';
 import type { UserGroupDTO } from '../../../../../generated';
 // min 5 characters, 1 upper case letter, 1 lower case letter, 1 numeric digit.
 export const passwordRules = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{5,}$/;
@@ -9,7 +10,7 @@ export const userSchema = (t: (key: string) => string) =>
 	object().shape({
 		userName: string()
 			.min(2)
-			.max(50)
+			.max(FIELD_LENGTHS.UserDTO.userName)
 			.matches(userNameRules, t('user.validateUserNameRegex'))
 			.required(t('user.validateUserName')),
 		userGroupName: object<UserGroupDTO>({

--- a/src/components/accessories/admin/vaccines/vaccineForm/VaccineForm.tsx
+++ b/src/components/accessories/admin/vaccines/vaccineForm/VaccineForm.tsx
@@ -9,7 +9,7 @@ import DiscardButton from '~/components/accessories/discardButton/DiscardButton'
 import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -146,6 +146,7 @@ const VaccineForm: FC<IVaccineFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading || !creationMode}
+							maxLength={FIELD_LENGTHS.VaccineDTO.code}
 						/>
 					</div>
 					<div className="vaccineForm__item">
@@ -171,6 +172,7 @@ const VaccineForm: FC<IVaccineFormProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.VaccineDTO.description}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admin/wards/wardForm/WardForm.tsx
+++ b/src/components/accessories/admin/wards/wardForm/WardForm.tsx
@@ -9,7 +9,7 @@ import ResetButton from '~/components/accessories/resetButton/resetButton';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import { FIELD_VALIDATION } from '~/types';
 import checkIcon from '../../../../../assets/check-icon.png';
-import { PATHS } from '../../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../../consts';
 import {
 	formatAllFieldValues,
 	getFromFields,
@@ -57,7 +57,10 @@ const WardForm: FC<IWardProps> = ({
 
 	const validationSchema = object({
 		code: string()
-			.max(3, t('validations.maxLength', { max: 3 }))
+			.max(
+				FIELD_LENGTHS.WardDTO.code,
+				t('validations.maxLength', { max: FIELD_LENGTHS.WardDTO.code }),
+			)
 			.required(t('common.required')),
 		description: string().required(t('common.required')),
 		email: string().email(t('validations.email')),
@@ -130,6 +133,7 @@ const WardForm: FC<IWardProps> = ({
 							type="text"
 							disabled={isLoading || !creationMode}
 							required={FIELD_VALIDATION.REQUIRED}
+							maxLength={FIELD_LENGTHS.WardDTO.code}
 						/>
 					</div>
 					<div className="wardForm__item halfWidth">
@@ -143,6 +147,7 @@ const WardForm: FC<IWardProps> = ({
 							type="text"
 							disabled={isLoading}
 							required={FIELD_VALIDATION.REQUIRED}
+							maxLength={FIELD_LENGTHS.WardDTO.description}
 						/>
 					</div>
 				</div>
@@ -157,6 +162,7 @@ const WardForm: FC<IWardProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.WardDTO.email}
 						/>
 					</div>
 					<div className="wardForm__item thirdWidth">
@@ -169,6 +175,7 @@ const WardForm: FC<IWardProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.WardDTO.telephone}
 						/>
 					</div>
 					<div className="wardForm__item thirdWidth">
@@ -181,6 +188,7 @@ const WardForm: FC<IWardProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.WardDTO.fax}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admission/admissionForm/AdmissionForm.tsx
+++ b/src/components/accessories/admission/admissionForm/AdmissionForm.tsx
@@ -330,6 +330,7 @@ const AdmissionForm: FC<AdmissionProps> = ({
 							type="text"
 							disabled={isLoading}
 							maxLength={50}
+							showRemaining
 						/>
 					</div>
 				</div>
@@ -506,6 +507,7 @@ const AdmissionForm: FC<AdmissionProps> = ({
 							rows={5}
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.AdmissionDTO.note}
+							showRemaining
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/admission/admissionForm/AdmissionForm.tsx
+++ b/src/components/accessories/admission/admissionForm/AdmissionForm.tsx
@@ -34,6 +34,7 @@ import ConfirmationDialog from '../../confirmationDialog/ConfirmationDialog';
 import DateField from '../../dateField/DateField';
 import TextField from '../../textField/TextField';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { AdmissionProps } from './types';
 
 const AdmissionForm: FC<AdmissionProps> = ({
@@ -504,7 +505,7 @@ const AdmissionForm: FC<AdmissionProps> = ({
 							onBlur={formik.handleBlur}
 							rows={5}
 							disabled={isLoading}
-							maxLength={65535}
+							maxLength={FIELD_LENGTHS.AdmissionDTO.note}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/autocompleteField/AutocompleteField.tsx
+++ b/src/components/accessories/autocompleteField/AutocompleteField.tsx
@@ -43,6 +43,7 @@ const AutocompleteField: FC<IProps> = ({
 	handleHomeEndKeys,
 	options_limit = 10,
 	maxLength,
+	showRemaining = false,
 	optionsComparator = (option: DefaultOptionType, val: string | number) =>
 		`${option.value}` === `${val}`,
 }) => {
@@ -167,7 +168,7 @@ const AutocompleteField: FC<IProps> = ({
 							inputProps={{ ...params.inputProps, maxLength }}
 							fullWidth
 						/>
-						{maxLength && maxLength > 0 && (
+						{showRemaining && maxLength && maxLength > 0 && (
 							<div
 								style={{
 									bottom: '-9px',

--- a/src/components/accessories/autocompleteField/AutocompleteField.tsx
+++ b/src/components/accessories/autocompleteField/AutocompleteField.tsx
@@ -170,6 +170,7 @@ const AutocompleteField: FC<IProps> = ({
 						/>
 						{showRemaining && maxLength && maxLength > 0 && (
 							<div
+								data-cy="remaining-chars"
 								style={{
 									bottom: '-9px',
 									transform: 'translate(14px, -6px) scale(0.75)',

--- a/src/components/accessories/autocompleteField/types.ts
+++ b/src/components/accessories/autocompleteField/types.ts
@@ -25,6 +25,7 @@ export interface IProps {
 	handleHomeEndKeys?: boolean;
 	options_limit?: number;
 	maxLength?: number;
+	showRemaining?: boolean;
 }
 export type DefaultOptionType = {
 	value: string | number | React.ReactElement;

--- a/src/components/accessories/currentAdmission/currentAdmissionForm/CurrentAdmissionForm.tsx
+++ b/src/components/accessories/currentAdmission/currentAdmissionForm/CurrentAdmissionForm.tsx
@@ -8,6 +8,7 @@ import {
 	useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { FIELD_LENGTHS } from '~/consts';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../assets/check-icon.png';
 import type {
@@ -248,6 +249,7 @@ export const CurrentAdmissionForm: FunctionComponent<IOwnProps> = ({
 							onBlur={formik.handleBlur}
 							rows={5}
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.AdmissionDTO.note}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/discharge/dischargeForm/DischargeForm.tsx
+++ b/src/components/accessories/discharge/dischargeForm/DischargeForm.tsx
@@ -26,6 +26,7 @@ import ConfirmationDialog from '../../confirmationDialog/ConfirmationDialog';
 import DateField from '../../dateField/DateField';
 import TextField from '../../textField/TextField';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { DischargeProps } from './types';
 
 const DischargeForm: FC<DischargeProps> = ({
@@ -300,7 +301,7 @@ const DischargeForm: FC<DischargeProps> = ({
 							onBlur={formik.handleBlur}
 							rows={5}
 							disabled={isLoading}
-							maxLength={65535}
+							maxLength={FIELD_LENGTHS.AdmissionDTO.note}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/discharge/dischargeForm/DischargeForm.tsx
+++ b/src/components/accessories/discharge/dischargeForm/DischargeForm.tsx
@@ -302,6 +302,7 @@ const DischargeForm: FC<DischargeProps> = ({
 							rows={5}
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.AdmissionDTO.note}
+							showRemaining
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/laboratory/examForm/ExamForm.tsx
+++ b/src/components/accessories/laboratory/examForm/ExamForm.tsx
@@ -10,7 +10,7 @@ import SelectField from '~/components/accessories/selectField/SelectField';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import checkIcon from '../../../../assets/check-icon.png';
 import warningIcon from '../../../../assets/warning-icon.png';
-import { PATHS } from '../../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../../consts';
 import {
 	type LaboratoryDTO,
 	LaboratoryDTOInOutPatientEnum,
@@ -155,10 +155,12 @@ const ExamForm: FC<ExamProps> = ({
 		result: string(),
 		note: string().test({
 			name: 'maxLength',
-			message: t('common.maxlengthexceeded', { maxLength: 255 }),
+			message: t('common.maxlengthexceeded', {
+				maxLength: FIELD_LENGTHS.LaboratoryDTO.note,
+			}),
 			test: (value) => {
 				if (!value) return true;
-				return value.length <= 255;
+				return value.length <= FIELD_LENGTHS.LaboratoryDTO.note;
 			},
 		}),
 	});
@@ -443,7 +445,7 @@ const ExamForm: FC<ExamProps> = ({
 								onBlur={formik.handleBlur}
 								type="text"
 								disabled={isLoading}
-								maxLength={255}
+								maxLength={FIELD_LENGTHS.LaboratoryDTO.note}
 							/>
 						</div>
 					</div>

--- a/src/components/accessories/laboratory/examForm/ExamForm.tsx
+++ b/src/components/accessories/laboratory/examForm/ExamForm.tsx
@@ -446,6 +446,7 @@ const ExamForm: FC<ExamProps> = ({
 								type="text"
 								disabled={isLoading}
 								maxLength={FIELD_LENGTHS.LaboratoryDTO.note}
+								showRemaining
 							/>
 						</div>
 					</div>

--- a/src/components/accessories/patientDataForm/PatientDataForm.tsx
+++ b/src/components/accessories/patientDataForm/PatientDataForm.tsx
@@ -38,6 +38,7 @@ import { ProfilePicture } from '../profilePicture/ProfilePicture';
 import SelectField from '../selectField/SelectField';
 import TextField from '../textField/TextField';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { TAgeFieldName, TProps } from './types';
 import { useCityOptions } from './useCityOptions';
 
@@ -243,7 +244,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									? FIELD_VALIDATION.SUGGESTED
 									: FIELD_VALIDATION.REQUIRED
 							}
-							maxLength={50}
+							maxLength={FIELD_LENGTHS.PatientDTO.firstName}
 						/>
 					</div>
 					<div className="patientDataForm__item">
@@ -260,7 +261,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									? FIELD_VALIDATION.SUGGESTED
 									: FIELD_VALIDATION.REQUIRED
 							}
-							maxLength={50}
+							maxLength={FIELD_LENGTHS.PatientDTO.secondName}
 						/>
 					</div>
 
@@ -278,7 +279,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									? FIELD_VALIDATION.SUGGESTED
 									: FIELD_VALIDATION.IDLE
 							}
-							maxLength={30}
+							maxLength={FIELD_LENGTHS.PatientDTO.taxCode}
 						/>
 					</div>
 				</div>
@@ -415,7 +416,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									? FIELD_VALIDATION.SUGGESTED
 									: FIELD_VALIDATION.IDLE
 							}
-							maxLength={50}
+							maxLength={FIELD_LENGTHS.PatientDTO.motherName}
 						/>
 					</div>
 
@@ -433,7 +434,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									? FIELD_VALIDATION.SUGGESTED
 									: FIELD_VALIDATION.IDLE
 							}
-							maxLength={50}
+							maxLength={FIELD_LENGTHS.PatientDTO.fatherName}
 						/>
 					</div>
 
@@ -472,7 +473,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									? FIELD_VALIDATION.SUGGESTED
 									: FIELD_VALIDATION.IDLE
 							}
-							maxLength={50}
+							maxLength={FIELD_LENGTHS.PatientDTO.address}
 						/>
 					</div>
 
@@ -512,7 +513,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 											? FIELD_VALIDATION.SUGGESTED
 											: FIELD_VALIDATION.IDLE
 									}
-									maxLength={50}
+									maxLength={FIELD_LENGTHS.PatientDTO.telephone}
 								/>
 							</div>
 						</Tooltip>
@@ -556,7 +557,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									? FIELD_VALIDATION.SUGGESTED
 									: FIELD_VALIDATION.IDLE
 							}
-							maxLength={65535}
+							maxLength={FIELD_LENGTHS.PatientDTO.note}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientDataForm/PatientDataForm.tsx
+++ b/src/components/accessories/patientDataForm/PatientDataForm.tsx
@@ -245,6 +245,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									: FIELD_VALIDATION.REQUIRED
 							}
 							maxLength={FIELD_LENGTHS.PatientDTO.firstName}
+							showRemaining
 						/>
 					</div>
 					<div className="patientDataForm__item">
@@ -262,6 +263,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									: FIELD_VALIDATION.REQUIRED
 							}
 							maxLength={FIELD_LENGTHS.PatientDTO.secondName}
+							showRemaining
 						/>
 					</div>
 
@@ -280,6 +282,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									: FIELD_VALIDATION.IDLE
 							}
 							maxLength={FIELD_LENGTHS.PatientDTO.taxCode}
+							showRemaining
 						/>
 					</div>
 				</div>
@@ -417,6 +420,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									: FIELD_VALIDATION.IDLE
 							}
 							maxLength={FIELD_LENGTHS.PatientDTO.motherName}
+							showRemaining
 						/>
 					</div>
 
@@ -435,6 +439,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									: FIELD_VALIDATION.IDLE
 							}
 							maxLength={FIELD_LENGTHS.PatientDTO.fatherName}
+							showRemaining
 						/>
 					</div>
 
@@ -474,6 +479,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									: FIELD_VALIDATION.IDLE
 							}
 							maxLength={FIELD_LENGTHS.PatientDTO.address}
+							showRemaining
 						/>
 					</div>
 
@@ -493,6 +499,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							selectOnFocus={true}
 							handleHomeEndKeys={true}
 							maxLength={FIELD_LENGTHS.PatientDTO.city}
+							showRemaining
 						/>
 					</div>
 
@@ -514,6 +521,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 											: FIELD_VALIDATION.IDLE
 									}
 									maxLength={FIELD_LENGTHS.PatientDTO.telephone}
+									showRemaining
 								/>
 							</div>
 						</Tooltip>
@@ -558,6 +566,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 									: FIELD_VALIDATION.IDLE
 							}
 							maxLength={FIELD_LENGTHS.PatientDTO.note}
+							showRemaining
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientDataForm/PatientDataForm.tsx
+++ b/src/components/accessories/patientDataForm/PatientDataForm.tsx
@@ -492,7 +492,7 @@ const PatientDataForm: FunctionComponent<TProps> = ({
 							clearOnBlur={true}
 							selectOnFocus={true}
 							handleHomeEndKeys={true}
-							maxLength={50}
+							maxLength={FIELD_LENGTHS.PatientDTO.city}
 						/>
 					</div>
 

--- a/src/components/accessories/patientExams/ExamForm/ExamForm.tsx
+++ b/src/components/accessories/patientExams/ExamForm/ExamForm.tsx
@@ -22,6 +22,7 @@ import DateField from '../../dateField/DateField';
 import TextField from '../../textField/TextField';
 import ExamRowTable from '../examRowTable/ExamRowTable';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { ExamProps } from './types';
 
 const ExamForm: FC<ExamProps> = ({
@@ -54,10 +55,12 @@ const ExamForm: FC<ExamProps> = ({
 		result: string().required(t('common.required')),
 		note: string().test({
 			name: 'maxLength',
-			message: t('common.maxlengthexceeded', { maxLength: 255 }),
+			message: t('common.maxlengthexceeded', {
+				maxLength: FIELD_LENGTHS.LaboratoryDTO.note,
+			}),
 			test: (value) => {
 				if (!value) return true;
-				return value.length <= 255;
+				return value.length <= FIELD_LENGTHS.LaboratoryDTO.note;
 			},
 		}),
 	});
@@ -305,7 +308,7 @@ const ExamForm: FC<ExamProps> = ({
 							onBlur={formik.handleBlur}
 							type="text"
 							disabled={isLoading}
-							maxLength={255}
+							maxLength={FIELD_LENGTHS.LaboratoryDTO.note}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientExams/ExamForm/ExamForm.tsx
+++ b/src/components/accessories/patientExams/ExamForm/ExamForm.tsx
@@ -309,6 +309,7 @@ const ExamForm: FC<ExamProps> = ({
 							type="text"
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.LaboratoryDTO.note}
+							showRemaining
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientExtraData/patientExtraData.tsx
+++ b/src/components/accessories/patientExtraData/patientExtraData.tsx
@@ -122,6 +122,7 @@ export const PatientExtraData: FunctionComponent<IOwnProps> = ({
 							type="string"
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.PatientDTO.anamnesis}
+							showRemaining
 						/>
 					) : (
 						<p className="item_content">
@@ -147,6 +148,7 @@ export const PatientExtraData: FunctionComponent<IOwnProps> = ({
 							type="string"
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.PatientDTO.allergies}
+							showRemaining
 						/>
 					) : (
 						<p className="item_content">

--- a/src/components/accessories/patientExtraData/patientExtraData.tsx
+++ b/src/components/accessories/patientExtraData/patientExtraData.tsx
@@ -24,6 +24,7 @@ import InfoBox from '../infoBox/InfoBox';
 import TextField from '../textField/TextField';
 import { initialFields } from './consts';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { IOwnProps, TActivityTransitionState } from './types';
 
 export const PatientExtraData: FunctionComponent<IOwnProps> = ({
@@ -120,7 +121,7 @@ export const PatientExtraData: FunctionComponent<IOwnProps> = ({
 							onBlur={formik.handleBlur}
 							type="string"
 							disabled={isLoading}
-							maxLength={255}
+							maxLength={FIELD_LENGTHS.PatientDTO.anamnesis}
 						/>
 					) : (
 						<p className="item_content">
@@ -145,7 +146,7 @@ export const PatientExtraData: FunctionComponent<IOwnProps> = ({
 							onBlur={formik.handleBlur}
 							type="string"
 							disabled={isLoading}
-							maxLength={255}
+							maxLength={FIELD_LENGTHS.PatientDTO.allergies}
 						/>
 					) : (
 						<p className="item_content">

--- a/src/components/accessories/patientOPD/patientOPDForm/PatientOPDForm.tsx
+++ b/src/components/accessories/patientOPD/patientOPDForm/PatientOPDForm.tsx
@@ -66,6 +66,7 @@ import OperationRowForm from '../../patientOperation/operationForm/OperationRowF
 import { opRowFields } from '../../patientOperation/opRowFields';
 import TextField from '../../textField/TextField';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { TProps } from './types';
 
 const PatientOPDForm: FunctionComponent<TProps> = ({
@@ -470,7 +471,7 @@ const PatientOPDForm: FunctionComponent<TProps> = ({
 										onBlur={formik.handleBlur}
 										type="string"
 										disabled={isLoading}
-										maxLength={65535}
+										maxLength={FIELD_LENGTHS.OpdDTO.note}
 									/>
 								</div>
 							</div>
@@ -528,7 +529,7 @@ const PatientOPDForm: FunctionComponent<TProps> = ({
 										onBlur={formik.handleBlur}
 										type="string"
 										disabled={isLoading}
-										maxLength={255}
+										maxLength={FIELD_LENGTHS.OpdDTO.prescription}
 									/>
 								</div>
 							</div>

--- a/src/components/accessories/patientOPD/patientOPDForm/PatientOPDForm.tsx
+++ b/src/components/accessories/patientOPD/patientOPDForm/PatientOPDForm.tsx
@@ -472,6 +472,7 @@ const PatientOPDForm: FunctionComponent<TProps> = ({
 										type="string"
 										disabled={isLoading}
 										maxLength={FIELD_LENGTHS.OpdDTO.note}
+										showRemaining
 									/>
 								</div>
 							</div>
@@ -530,6 +531,7 @@ const PatientOPDForm: FunctionComponent<TProps> = ({
 										type="string"
 										disabled={isLoading}
 										maxLength={FIELD_LENGTHS.OpdDTO.prescription}
+										showRemaining
 									/>
 								</div>
 							</div>

--- a/src/components/accessories/patientOperation/operationForm/OperationRowForm.tsx
+++ b/src/components/accessories/patientOperation/operationForm/OperationRowForm.tsx
@@ -243,6 +243,7 @@ const OperationRowForm: FC<OperationRowProps> = ({
 							rows={5}
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.OperationRowDTO.remarks}
+							showRemaining
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientOperation/operationForm/OperationRowForm.tsx
+++ b/src/components/accessories/patientOperation/operationForm/OperationRowForm.tsx
@@ -21,6 +21,7 @@ import DateField from '../../dateField/DateField';
 import SelectField from '../../selectField/SelectField';
 import TextField from '../../textField/TextField';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { OperationRowProps } from './types';
 
 const OperationRowForm: FC<OperationRowProps> = ({
@@ -241,7 +242,7 @@ const OperationRowForm: FC<OperationRowProps> = ({
 							onBlur={formik.handleBlur}
 							rows={5}
 							disabled={isLoading}
-							maxLength={250}
+							maxLength={FIELD_LENGTHS.OperationRowDTO.remarks}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientPicker/PatientPicker.tsx
+++ b/src/components/accessories/patientPicker/PatientPicker.tsx
@@ -20,6 +20,7 @@ import { TextField as MaterialComponent, Pagination } from '@mui/material';
 import { GridCloseIcon } from '@mui/x-data-grid';
 import { useFormik } from 'formik';
 import { get, has } from 'lodash';
+import { FIELD_LENGTHS } from '~/consts';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import type { PatientDTO } from '../../../generated';
 import {
@@ -282,7 +283,7 @@ const PatientPicker: FC<IProps> = ({
 										onBlur={formik.handleBlur}
 										type="text"
 										disabled={isLoading}
-										maxLength={50}
+										maxLength={FIELD_LENGTHS.PatientDTO.firstName}
 									/>
 								</div>
 								<div className="patientSearchForm__item">
@@ -295,7 +296,7 @@ const PatientPicker: FC<IProps> = ({
 										onBlur={formik.handleBlur}
 										type="text"
 										disabled={isLoading}
-										maxLength={50}
+										maxLength={FIELD_LENGTHS.PatientDTO.secondName}
 									/>
 								</div>
 							</div>
@@ -310,7 +311,7 @@ const PatientPicker: FC<IProps> = ({
 										onBlur={formik.handleBlur}
 										type="text"
 										disabled={isLoading}
-										maxLength={50}
+										maxLength={FIELD_LENGTHS.PatientDTO.address}
 									/>
 								</div>
 								<div className="patientSearchForm__item">

--- a/src/components/accessories/patientPicker/PatientPicker.tsx
+++ b/src/components/accessories/patientPicker/PatientPicker.tsx
@@ -284,6 +284,7 @@ const PatientPicker: FC<IProps> = ({
 										type="text"
 										disabled={isLoading}
 										maxLength={FIELD_LENGTHS.PatientDTO.firstName}
+										showRemaining
 									/>
 								</div>
 								<div className="patientSearchForm__item">
@@ -297,6 +298,7 @@ const PatientPicker: FC<IProps> = ({
 										type="text"
 										disabled={isLoading}
 										maxLength={FIELD_LENGTHS.PatientDTO.secondName}
+										showRemaining
 									/>
 								</div>
 							</div>
@@ -312,6 +314,7 @@ const PatientPicker: FC<IProps> = ({
 										type="text"
 										disabled={isLoading}
 										maxLength={FIELD_LENGTHS.PatientDTO.address}
+										showRemaining
 									/>
 								</div>
 								<div className="patientSearchForm__item">

--- a/src/components/accessories/patientTherapy/therapyForm/TherapyForm.tsx
+++ b/src/components/accessories/patientTherapy/therapyForm/TherapyForm.tsx
@@ -5,6 +5,7 @@ import type React from 'react';
 import { type FC, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { number, object, string } from 'yup';
+import { FIELD_LENGTHS } from '~/consts';
 import { useAppSelector } from '~/libraries/hooks/redux';
 import warningIcon from '../../../../assets/warning-icon.png';
 import { renderDate } from '../../../../libraries/formatUtils/dataFormatting';
@@ -308,6 +309,7 @@ const TherapyForm: FC<TherapyProps> = ({
 							errorText={getErrorText('note')}
 							onBlur={formik.handleBlur}
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.TherapyRowDTO.note}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientTriage/patientTriageForm/PatientTriageForm.tsx
+++ b/src/components/accessories/patientTriage/patientTriageForm/PatientTriageForm.tsx
@@ -22,6 +22,7 @@ import DateField from '../../dateField/DateField';
 import SelectField from '../../selectField/SelectField';
 import TextField from '../../textField/TextField';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { TProps } from './types';
 
 const PatientTriageForm: FunctionComponent<TProps> = ({
@@ -381,7 +382,7 @@ const PatientTriageForm: FunctionComponent<TProps> = ({
 							onBlur={formik.handleBlur}
 							multiline
 							disabled={isLoading}
-							maxLength={65535}
+							maxLength={FIELD_LENGTHS.PatientExaminationDTO.pex_note}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientTriage/patientTriageForm/PatientTriageForm.tsx
+++ b/src/components/accessories/patientTriage/patientTriageForm/PatientTriageForm.tsx
@@ -383,6 +383,7 @@ const PatientTriageForm: FunctionComponent<TProps> = ({
 							multiline
 							disabled={isLoading}
 							maxLength={FIELD_LENGTHS.PatientExaminationDTO.pex_note}
+							showRemaining
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/patientVisit/patientVisitForm/PatientVisitForm.tsx
+++ b/src/components/accessories/patientVisit/patientVisitForm/PatientVisitForm.tsx
@@ -23,6 +23,7 @@ import ConfirmationDialog from '../../confirmationDialog/ConfirmationDialog';
 import DateField from '../../dateField/DateField';
 import TextField from '../../textField/TextField';
 import './styles.scss';
+import { FIELD_LENGTHS } from '~/consts';
 import type { TProps } from './types';
 
 const PatientVisitForm: FunctionComponent<TProps> = ({
@@ -174,6 +175,7 @@ const PatientVisitForm: FunctionComponent<TProps> = ({
 							onBlur={formik.handleBlur}
 							type="string"
 							disabled={isLoading}
+							maxLength={FIELD_LENGTHS.VisitDTO.service}
 						/>
 					</div>
 				</div>

--- a/src/components/accessories/textField/TextField.tsx
+++ b/src/components/accessories/textField/TextField.tsx
@@ -19,6 +19,7 @@ const TextField: FunctionComponent<IProps> = ({
 	rows = 10,
 	required = FIELD_VALIDATION.IDLE,
 	maxLength,
+	showRemaining = false,
 	inputProps,
 }) => {
 	const { t } = useTranslation();
@@ -48,7 +49,7 @@ const TextField: FunctionComponent<IProps> = ({
 				InputLabelProps={{ shrink: !!field.value }}
 				required={required === FIELD_VALIDATION.REQUIRED}
 			/>
-			{maxLength && maxLength > 0 && (
+			{showRemaining && maxLength && maxLength > 0 && (
 				<div
 					style={{
 						bottom: '-9px',
@@ -63,7 +64,7 @@ const TextField: FunctionComponent<IProps> = ({
 				>
 					<small>
 						{t('common.remainingchars', {
-							current: maxLength - field.value.length,
+							current: maxLength - (field.value?.length ?? 0),
 							max: maxLength,
 						})}
 					</small>

--- a/src/components/accessories/textField/TextField.tsx
+++ b/src/components/accessories/textField/TextField.tsx
@@ -51,6 +51,7 @@ const TextField: FunctionComponent<IProps> = ({
 			/>
 			{showRemaining && maxLength && maxLength > 0 && (
 				<div
+					data-cy="remaining-chars"
 					style={{
 						bottom: '-9px',
 						transform: 'translate(14px, -6px) scale(0.75)',

--- a/src/components/accessories/textField/types.ts
+++ b/src/components/accessories/textField/types.ts
@@ -24,5 +24,6 @@ export interface IProps {
 	rows?: number;
 	required?: FIELD_VALIDATION;
 	maxLength?: number;
+	showRemaining?: boolean;
 	inputProps?: Record<string, unknown>;
 }

--- a/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
+++ b/src/components/activities/changePasswordActivity/ChangePasswordActivity.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { object, ref, string } from 'yup';
 import { useAppDispatch } from '~/libraries/hooks/redux';
 import logo from '../../../assets/logo-color.svg';
-import { AUTH_KEY } from '../../../consts';
+import { AUTH_KEY, FIELD_LENGTHS } from '../../../consts';
 import { useLandingPageRoute } from '../../../libraries/hooks/useLandingPageRoute';
 import { SessionStorage } from '../../../libraries/storage/storage';
 import { changePassword, clearMustChangePassword } from '../../../state/main';
@@ -113,6 +113,7 @@ export const ChangePasswordActivity: FC = () => {
 								inputProps={{
 									autoComplete: 'new-password',
 								}}
+								maxLength={FIELD_LENGTHS.UserDTO.passwd}
 							/>
 						</div>
 						<div className="login__panel__textField">
@@ -127,6 +128,7 @@ export const ChangePasswordActivity: FC = () => {
 								inputProps={{
 									autoComplete: 'new-password',
 								}}
+								maxLength={FIELD_LENGTHS.UserDTO.passwd}
 							/>
 						</div>
 						<div

--- a/src/components/activities/searchPatientActivity/SearchPatientActivity.tsx
+++ b/src/components/activities/searchPatientActivity/SearchPatientActivity.tsx
@@ -8,7 +8,7 @@ import { number, object } from 'yup';
 import { useAppDispatch, useAppSelector } from '~/libraries/hooks/redux';
 import { searchPatient, searchPatientsReset } from '~/state/patients';
 import SearchIcon from '../../../assets/SearchIcon';
-import { PATHS } from '../../../consts';
+import { FIELD_LENGTHS, PATHS } from '../../../consts';
 import { formatAllFieldValues } from '../../../libraries/formDataHandling/functions';
 import { Permission } from '../../../libraries/permissionUtils/Permission';
 import { scrollToElement } from '../../../libraries/uiUtils/scrollToElement';
@@ -198,6 +198,7 @@ export const SearchPatientActivity = () => {
 											errorText={getErrorText('firstName')}
 											onBlur={formik.handleBlur}
 											disabled={isSearchById}
+											maxLength={FIELD_LENGTHS.PatientDTO.firstName}
 										/>
 									</div>
 									<div className="searchPatient__formItem">
@@ -209,6 +210,7 @@ export const SearchPatientActivity = () => {
 											errorText={getErrorText('secondName')}
 											onBlur={formik.handleBlur}
 											disabled={isSearchById}
+											maxLength={FIELD_LENGTHS.PatientDTO.secondName}
 										/>
 									</div>
 								</div>
@@ -236,6 +238,7 @@ export const SearchPatientActivity = () => {
 											errorText={getErrorText('address')}
 											onBlur={formik.handleBlur}
 											disabled={isSearchById}
+											maxLength={FIELD_LENGTHS.PatientDTO.address}
 										/>
 									</div>
 								</div>

--- a/src/consts.test.ts
+++ b/src/consts.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { FIELD_LENGTHS } from './consts';
+
+/**
+ * Reads `components.schemas.<DTO>.properties.<field>.maxLength` out of the
+ * specification. The block is read by indentation rather than through a YAML
+ * parser so that the check costs the project no dependency; a specification
+ * written differently yields no constraint, and every expectation below fails.
+ */
+const readPublishedLengths = (): Record<string, Record<string, number>> => {
+	const lines = readFileSync(
+		new URL('../api/oh.yaml', import.meta.url),
+		'utf8',
+	).split('\n');
+
+	const published: Record<string, Record<string, number>> = {};
+	let inSchemas = false;
+	let schema = '';
+	let property = '';
+
+	for (const line of lines) {
+		if (/^ {2}schemas:\s*$/.test(line)) {
+			inSchemas = true;
+			continue;
+		}
+		if (!inSchemas) continue;
+		if (/^ {0,2}\S/.test(line)) {
+			inSchemas = false;
+			continue;
+		}
+
+		const schemaName = line.match(/^ {4}([A-Za-z0-9_]+):\s*$/);
+		if (schemaName) {
+			schema = schemaName[1];
+			property = '';
+			continue;
+		}
+
+		const propertyName = line.match(/^ {8}([A-Za-z0-9_]+):\s*$/);
+		if (propertyName) {
+			property = propertyName[1];
+			continue;
+		}
+
+		const maxLength = line.match(/^ {10}maxLength: (\d+)\s*$/);
+		if (maxLength && schema && property) {
+			published[schema] ??= {};
+			published[schema][property] = Number(maxLength[1]);
+		}
+	}
+
+	return published;
+};
+
+const published = readPublishedLengths();
+
+const declared: Record<string, Record<string, number>> = FIELD_LENGTHS;
+
+const cases = Object.entries(declared).flatMap(([schema, fields]) =>
+	Object.entries(fields).map(([property, length]) => ({
+		field: `${schema}.${property}`,
+		schema,
+		property,
+		length,
+	})),
+);
+
+describe('FIELD_LENGTHS', () => {
+	it('reads the lengths the specification publishes', () => {
+		expect(Object.keys(published).length).toBeGreaterThan(0);
+	});
+
+	it.each(cases)('$field keeps the length the API accepts', ({
+		schema,
+		property,
+		length,
+	}) => {
+		expect(published[schema]?.[property]).toBe(length);
+	});
+});

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -33,7 +33,7 @@ export const FIELD_LENGTHS = {
 	MedicalTypeDTO: { code: 1, description: 30 },
 	OpdDTO: { note: 65535, prescription: 255 },
 	OperationDTO: { code: 10, description: 50 },
-	OperationRowDTO: { prescriber: 150, opResult: 250, remarks: 250 },
+	OperationRowDTO: { remarks: 250 },
 	OperationTypeDTO: { code: 2, description: 50 },
 	PatientDTO: {
 		firstName: 50,
@@ -64,7 +64,7 @@ export const FIELD_LENGTHS = {
 	UserGroupDTO: { code: 50, desc: 128 },
 	VaccineDTO: { code: 10, description: 50 },
 	VaccineTypeDTO: { code: 1, description: 50 },
-	VisitDTO: { note: 65535, service: 45 },
+	VisitDTO: { service: 45 },
 	WardDTO: { code: 3, description: 50, telephone: 50, fax: 50, email: 50 },
 } as const;
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -5,6 +5,69 @@ export const MOBILE_BREAKPOINT = 768;
 export const TOKEN_EXPIRATION_TIMEOUT = 60000;
 export const REFRESH_TOKEN_EXPIRATION_TIMEOUT = 0;
 
+/**
+ * Maximum length the API accepts for each field, mirroring the `maxLength`
+ * constraints published in `api/oh.yaml`, which in turn match the database
+ * column sizes. Fields the specification does not constrain are not listed.
+ */
+export const FIELD_LENGTHS = {
+	AdmissionDTO: { note: 65535 },
+	AdmissionTypeDTO: { description: 50 },
+	DeliveryResultTypeDTO: { description: 50 },
+	DeliveryTypeDTO: { description: 50 },
+	DischargeTypeDTO: { description: 50 },
+	DiseaseDTO: { code: 10, description: 50 },
+	DiseaseTypeDTO: { code: 2, description: 110 },
+	ExamDTO: { code: 10, description: 100, defaultResult: 50 },
+	ExamTypeDTO: { description: 50 },
+	HospitalDTO: {
+		description: 255,
+		address: 255,
+		city: 255,
+		telephone: 50,
+		fax: 50,
+		email: 50,
+		currencyCod: 3,
+	},
+	LaboratoryDTO: { note: 255 },
+	MedicalTypeDTO: { code: 1, description: 30 },
+	OpdDTO: { note: 65535, prescription: 255 },
+	OperationDTO: { code: 10, description: 50 },
+	OperationRowDTO: { prescriber: 150, opResult: 250, remarks: 250 },
+	OperationTypeDTO: { code: 2, description: 50 },
+	PatientDTO: {
+		firstName: 50,
+		secondName: 50,
+		address: 50,
+		city: 50,
+		telephone: 50,
+		note: 65535,
+		motherName: 50,
+		fatherName: 50,
+		taxCode: 30,
+		allergies: 255,
+		anamnesis: 255,
+	},
+	PatientExaminationDTO: { pex_note: 2000 },
+	PregnantTreatmentTypeDTO: { code: 10, description: 50 },
+	SupplierDTO: {
+		supName: 100,
+		supAddress: 150,
+		supTaxcode: 50,
+		supPhone: 20,
+		supFax: 20,
+		supEmail: 100,
+		supNote: 200,
+	},
+	TherapyRowDTO: { note: 65535 },
+	UserDTO: { userName: 50, passwd: 50, desc: 128 },
+	UserGroupDTO: { code: 50, desc: 128 },
+	VaccineDTO: { code: 10, description: 50 },
+	VaccineTypeDTO: { code: 1, description: 50 },
+	VisitDTO: { note: 65535, service: 45 },
+	WardDTO: { code: 3, description: 50, telephone: 50, fax: 50, email: 50 },
+} as const;
+
 export const PATHS = {
 	home: '/',
 	login: '/login',

--- a/src/libraries/authUtils/getAuthenticationFromSession.ts
+++ b/src/libraries/authUtils/getAuthenticationFromSession.ts
@@ -4,8 +4,13 @@ import { SessionStorage } from '../storage/storage';
 
 export const getAuthenticationFromSession = (): IAuthentication => {
 	const { permissions } = SessionStorage.read(PERMISSION_KEY);
-	const { username, token, mustChangePassword, passwordExpired, passwordLeaseDays } =
-		SessionStorage.read(AUTH_KEY);
+	const {
+		username,
+		token,
+		mustChangePassword,
+		passwordExpired,
+		passwordLeaseDays,
+	} = SessionStorage.read(AUTH_KEY);
 
 	if (!(token && username && permissions)) {
 		throw new Error('unauthenticated');

--- a/src/mocks/routes/diseaseTypes.ts
+++ b/src/mocks/routes/diseaseTypes.ts
@@ -9,7 +9,7 @@ export const diseaseTypeRoutes = (server: PollyServer) => {
 		server.post('/').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'FA':
 					res.status(400).json({ message: 'Fail to create disease type' });
 					break;
 				default:
@@ -19,7 +19,7 @@ export const diseaseTypeRoutes = (server: PollyServer) => {
 		server.put('/').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'FA':
 					res.status(400).json({ message: 'Fail to update disease type' });
 					break;
 				default:
@@ -29,7 +29,7 @@ export const diseaseTypeRoutes = (server: PollyServer) => {
 		server.delete('/:code').intercept((req, res) => {
 			const code = req.params.code;
 			switch (code) {
-				case 'FAIL':
+				case 'FA':
 					res.status(400).json({ message: 'Fail to delete disease type' });
 					break;
 				default:

--- a/src/mocks/routes/medicalTypes.ts
+++ b/src/mocks/routes/medicalTypes.ts
@@ -20,7 +20,7 @@ export const medicalTypesRoutes = (server: PollyServer) => {
 		server.post('/').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'F':
 					res.status(400).json({ message: 'Fail to create medical type' });
 					break;
 				default:
@@ -30,7 +30,7 @@ export const medicalTypesRoutes = (server: PollyServer) => {
 		server.put('/').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'F':
 					res.status(400).json({ message: 'Fail to update medical type' });
 					break;
 				default:
@@ -40,7 +40,7 @@ export const medicalTypesRoutes = (server: PollyServer) => {
 		server.delete('/:code').intercept((req, res) => {
 			const code = req.params.code;
 			switch (code) {
-				case 'FAIL':
+				case 'F':
 					res.status(400).json({ message: 'Fail to delete medical type' });
 					break;
 				default:

--- a/src/mocks/routes/operationTypes.ts
+++ b/src/mocks/routes/operationTypes.ts
@@ -9,7 +9,7 @@ export const operationTypeRoutes = (server: PollyServer) => {
 		server.post('/').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'FA':
 					res.status(400).json({ message: 'Fail to create operation type' });
 					break;
 				default:
@@ -19,7 +19,7 @@ export const operationTypeRoutes = (server: PollyServer) => {
 		server.put('/:code').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'FA':
 					res.status(400).json({ message: 'Fail to update operation type' });
 					break;
 				default:
@@ -29,7 +29,7 @@ export const operationTypeRoutes = (server: PollyServer) => {
 		server.delete('/:code').intercept((req, res) => {
 			const code = req.params.code;
 			switch (code) {
-				case 'FAIL':
+				case 'FA':
 					res.status(400).json({ message: 'Fail to delete operation type' });
 					break;
 				default:

--- a/src/mocks/routes/vaccineTypes.ts
+++ b/src/mocks/routes/vaccineTypes.ts
@@ -20,7 +20,7 @@ export const vaccineTypesRoutes = (server: PollyServer) => {
 		server.post('/').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'F':
 					res.status(400).json({ message: 'Fail to create vaccine type' });
 					break;
 				default:
@@ -30,7 +30,7 @@ export const vaccineTypesRoutes = (server: PollyServer) => {
 		server.put('/').intercept((req, res) => {
 			const body = req.jsonBody();
 			switch (body.code) {
-				case 'FAIL':
+				case 'F':
 					res.status(400).json({ message: 'Fail to update vaccine type' });
 					break;
 				default:
@@ -40,7 +40,7 @@ export const vaccineTypesRoutes = (server: PollyServer) => {
 		server.delete('/:code').intercept((req, res) => {
 			const code = req.params.code;
 			switch (code) {
-				case 'FAIL':
+				case 'F':
 					res.status(400).json({ message: 'Fail to delete vaccine type' });
 					break;
 				default:


### PR DESCRIPTION
Every form input bound to a DTO field now carries the `maxLength` the API publishes in `api/oh.yaml`, so the browser stops the input instead of letting the request fail server side. The limits live in one table, `FIELD_LENGTHS` in `src/consts.ts`.

**Two limits did not match the contract** and are corrected: supplier note 1500 → 200, examination note 65535 → 2000.

**One thing worth a look.** In `TextField` and `AutocompleteField`, `maxLength` also switched on a floating "Remaining : x / y" badge. Applying the limits took the call sites from 24 to 85, which would have added that badge to ~60 inputs that never had one — including every password field, where it showed how many characters the password holds. The badge now answers its own prop, `showRemaining`, off unless asked for; the 24 fields that displayed it keep it. Same commit fixes a render crash: the count read `field.value.length` on a description the contract makes optional.

**Tests**
- `src/consts.test.ts` — reads the limits back out of `api/oh.yaml` and compares them one field at a time (67 cases). Without it a wrong number would pass, since the e2e test reads the same constant the form reads.
- `cypress/integrations/field_length_limits.cy.ts` — 21 cases over 10 forms: the attribute, the truncation, the badge, and a group whose description is absent.

**Two questions for a maintainer**
1. `HospitalDTO.currencyCod` publishes maxLength 3 (example `EUR`), but `edit_hospital.cy.ts` types `FCFA`, which is now cut to `FCF`. Is the column right, or the test value?
2. `maxLength` does not shorten a value already stored, so a supplier note or examination note saved over the new limit can only be saved again after the user deletes text. Acceptable, or should the limits be relaxed?

**Running the suite locally:** the app follows the browser language, and several existing specs assert English copy, so they fail on a non-English machine. That is pre-existing and unrelated to this PR — `login_activity.cy.ts` fails the same way on `develop`. The spec added here asserts structure instead, and passes in any language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9F4QcEfqGDtydgS3Zvv18
