### PR TITLE
chore: Fix empty space below footer on Login/Forgot mobile views

### DIFF
--- a/src/components/activities/forgotActivity/styles.scss
+++ b/src/components/activities/forgotActivity/styles.scss
@@ -2,6 +2,10 @@
 @import "../../../../node_modules/susy/sass/susy";
 
 .forgot {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+
   .forgot__background {
     display: flex;
     flex-direction: column;
@@ -12,7 +16,8 @@
     background-color: $c-color-secondary;
     @include susy-media($smartphone) {
       padding: 50px 0 100px 0;
-      min-height: 100%;
+      min-height: auto;
+      flex: 1;
     }
   }
 

--- a/src/components/activities/loginActivity/styles.scss
+++ b/src/components/activities/loginActivity/styles.scss
@@ -2,6 +2,10 @@
 @import "../../../../node_modules/susy/sass/susy";
 
 .login {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+
   .login__background {
     display: flex;
     flex-direction: column;
@@ -12,7 +16,8 @@
     background-color: $c-color-secondary;
     @include susy-media($smartphone) {
       padding: 50px 0 100px 0;
-      min-height: 100%;
+      min-height: auto;
+      flex: 1;
     }
   }
 


### PR DESCRIPTION
## Problem
On the Login and Forgot-password pages, at phone widths, there is a blank gap below the footer instead of the footer sitting flush at the bottom of the viewport when page content is short.

## Root cause
`Footer` is `position: fixed` on desktop (hence the `120px` reserved in `.login__background`/`.forgot__background`'s `calc(100vh - 120px)`), but switches to `position: static` on the `$smartphone` breakpoint, rejoining normal document flow. #787 had already moved these containers from a fixed `height` to `min-height: 100%` on mobile to stop content from being clipped — but `%` needs a defined height on an ancestor, and neither `.login`/`.forgot` nor `html`/`body` sets one, so that `min-height` was effectively inert. The background panel collapsed to its content height, and any leftover viewport height showed up as a gap after the now-static footer.

## Fix
Standard sticky-footer flexbox layout instead of a hand-picked pixel offset:
- `.login` / `.forgot`: `display: flex; flex-direction: column; min-height: 100vh;`
- `.login__background` / `.forgot__background` (mobile only): `flex: 1` instead of `min-height: 100%`

This lets the background panel absorb exactly the leftover space and pushes the footer to the real bottom, with no magic number to keep in sync with the footer's actual height. Desktop is unaffected — `Footer` stays fixed/out of flow there, so the existing `calc(100vh - 120px)` rule is untouched. Applied identically to `loginActivity` and `forgotActivity` since they're exact structural siblings.

## Verification
Manual check on `/login` and `/forgot` at phone width (devtools responsive mode): no gap below the footer, footer sits at the true bottom, content still scrolls if taller than the viewport.
<img width="520" height="800" alt="image" src="https://github.com/user-attachments/assets/d51dc058-dabd-412f-9b0f-a09b17e59172" />
